### PR TITLE
Add reusable R2 event galleries and Muslim Chamber portfolio

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,6 +27,11 @@ export default defineConfig({
         protocol: 'https',
         hostname: 'i1.ytimg.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'photos.ayoubabed.xyz',
+        pathname: '/events/**',
+      },
     ],
   },
   vite: {

--- a/cloudflare/r2-gallery-cors.json
+++ b/cloudflare/r2-gallery-cors.json
@@ -1,0 +1,18 @@
+[
+  {
+    "AllowedOrigins": [
+      "https://ayoubabed.xyz",
+      "http://localhost:4321",
+      "http://127.0.0.1:4321"
+    ],
+    "AllowedMethods": ["GET", "HEAD"],
+    "AllowedHeaders": ["Range"],
+    "ExposeHeaders": [
+      "Content-Length",
+      "Content-Range",
+      "Content-Type",
+      "ETag"
+    ],
+    "MaxAgeSeconds": 86400
+  }
+]

--- a/docs/event-galleries.md
+++ b/docs/event-galleries.md
@@ -1,0 +1,78 @@
+# Event gallery workflow
+
+## One-time R2 setup
+
+1. In the Cloudflare R2 dashboard, open `alphabravomedia-galleries`.
+2. Connect the custom domain `photos.ayoubabed.xyz`.
+3. Keep the bucket publicly readable and disable the `r2.dev` development URL
+   after the custom domain is active.
+4. Apply `cloudflare/r2-gallery-cors.json` under the bucket CORS settings.
+
+After renewing Wrangler authentication, the same CORS policy can be applied
+from the project root:
+
+```powershell
+npx wrangler login
+npx wrangler r2 bucket cors set alphabravomedia-galleries --file cloudflare/r2-gallery-cors.json
+```
+
+## Export
+
+Export public gallery JPEGs before uploading:
+
+- 2400 pixels on the long edge
+- sRGB
+- progressive JPEG
+- quality 82 to 85
+- strip GPS and unnecessary EXIF metadata
+- preserve the camera filename when practical
+
+Example ImageMagick command:
+
+```powershell
+magick mogrify -path "C:\event\exports" -resize "2400x2400>" -colorspace sRGB -strip -interlace Plane -quality 84 "C:\event\edited\*.JPG"
+```
+
+## R2 object layout
+
+```text
+events/{event-slug}/
+  images/
+  downloads/
+    {event-slug}.zip
+```
+
+Upload the `images` folder and ZIP with the existing interactive rclone helper:
+
+```powershell
+& "C:\Users\User\Documents\Upload To Google Drive Script\upload.ps1"
+```
+
+Use `copy`, choose the `r2:` remote, and upload into the matching event prefix.
+
+## Generate portfolio metadata
+
+Generate paste-ready YAML after the files are uploaded:
+
+```powershell
+npm run gallery:manifest -- "C:\event\exports" "https://photos.ayoubabed.xyz/events/event-slug/images/" --output "gallery.yml"
+```
+
+Optional flags:
+
+```text
+--featured "P1290931.jpg,P1290947.jpg"
+--alt-prefix "Portrait from the Muslim Business Chamber networking event"
+--output "gallery.yml"
+```
+
+Copy the generated `gallery:` block into a portfolio MDX file based on
+`src/content/portfolio/EVENT_GALLERY_TEMPLATE.mdx.example`. Replace the
+generated sequential alt text with specific descriptions before publishing.
+
+## Verification
+
+- Open at least one image directly through `photos.ayoubabed.xyz`.
+- Verify an individual Download action saves a file instead of navigating away.
+- Verify the Download All ZIP opens from the gallery page.
+- Run `npm run verify` before deployment.

--- a/docs/muslim-chamber-gallery-upload.md
+++ b/docs/muslim-chamber-gallery-upload.md
@@ -1,0 +1,30 @@
+# Muslim Chamber of Commerce USA gallery upload
+
+Use this exact event slug:
+
+```text
+muslim-business-chamber-2026
+```
+
+Run `gallery-photos.cmd`, drag in the approved JPEG files or their containing
+folder, and enter:
+
+```text
+Event slug: muslim-business-chamber-2026
+Event title: Muslim Chamber of Commerce USA AI workshop
+```
+
+The uploader will publish to:
+
+```text
+r2:alphabravomedia-galleries/events/muslim-business-chamber-2026/images/
+r2:alphabravomedia-galleries/events/muslim-business-chamber-2026/downloads/muslim-business-chamber-2026.zip
+```
+
+After upload, merge the generated gallery YAML into:
+
+```text
+src/content/portfolio/muslim-business-chamber-2026.mdx
+```
+
+The gallery is now published in the portfolio project.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "update:youtube": "node scripts/update-latest-youtube-video.mjs",
+    "gallery:manifest": "node scripts/generate-event-gallery-manifest.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "deploy": "npm run build && wrangler deploy",

--- a/scripts/generate-event-gallery-manifest.mjs
+++ b/scripts/generate-event-gallery-manifest.mjs
@@ -1,0 +1,80 @@
+import { readdir, writeFile } from 'node:fs/promises'
+import { extname, join, resolve } from 'node:path'
+import sharp from 'sharp'
+import { stringify } from 'yaml'
+
+const args = process.argv.slice(2)
+const positional = args.filter((argument) => !argument.startsWith('--'))
+const optionValue = (name) => {
+  const index = args.indexOf(name)
+  return index >= 0 ? args[index + 1] : undefined
+}
+
+const [sourceDirectory, publicBaseUrl] = positional
+
+if (!sourceDirectory || !publicBaseUrl) {
+  console.error(
+    'Usage: npm run gallery:manifest -- <folder> <public-base-url> [--output <file>] [--featured <name1,name2>] [--alt-prefix <text>]',
+  )
+  process.exit(1)
+}
+
+let baseUrl
+try {
+  baseUrl = new URL(
+    publicBaseUrl.endsWith('/') ? publicBaseUrl : `${publicBaseUrl}/`,
+  )
+} catch {
+  console.error(`Invalid public base URL: ${publicBaseUrl}`)
+  process.exit(1)
+}
+
+const sourcePath = resolve(sourceDirectory)
+const outputPath = optionValue('--output')
+const altPrefix = optionValue('--alt-prefix') ?? 'Event photograph'
+const featured = new Set(
+  (optionValue('--featured') ?? '')
+    .split(',')
+    .map((filename) => filename.trim().toLowerCase())
+    .filter(Boolean),
+)
+const supportedExtensions = new Set(['.jpg', '.jpeg', '.png', '.webp', '.avif'])
+
+const filenames = (await readdir(sourcePath))
+  .filter((filename) =>
+    supportedExtensions.has(extname(filename).toLowerCase()),
+  )
+  .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+
+if (filenames.length === 0) {
+  console.error(`No supported images found in ${sourcePath}`)
+  process.exit(1)
+}
+
+const gallery = await Promise.all(
+  filenames.map(async (filename, index) => {
+    const metadata = await sharp(join(sourcePath, filename)).metadata()
+
+    if (!metadata.width || !metadata.height) {
+      throw new Error(`Could not read dimensions for ${filename}`)
+    }
+
+    return {
+      src: new URL(encodeURIComponent(filename), baseUrl).toString(),
+      width: metadata.width,
+      height: metadata.height,
+      alt: `${altPrefix} ${index + 1}`,
+      filename,
+      featured: featured.has(filename.toLowerCase()),
+    }
+  }),
+)
+
+const yaml = stringify({ gallery }, { lineWidth: 0 })
+
+if (outputPath) {
+  await writeFile(resolve(outputPath), yaml, 'utf8')
+  console.log(`Created ${resolve(outputPath)} with ${gallery.length} images.`)
+} else {
+  process.stdout.write(yaml)
+}

--- a/src/components/EventGallery.astro
+++ b/src/components/EventGallery.astro
@@ -1,6 +1,6 @@
 ---
 import { Image } from 'astro:assets'
-import { Download, Images } from 'lucide-react'
+import { ChevronDown, Download } from 'lucide-react'
 import EventLightbox from './EventLightbox'
 
 type GalleryImage = {
@@ -129,27 +129,18 @@ const galleryId = `event-gallery-${heading
     <summary
       class="focus-visible:ring-ring flex cursor-pointer list-none items-center justify-between gap-4 py-5 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset [&::-webkit-details-marker]:hidden"
     >
-      <span class="flex items-center gap-3">
-        <span
-          class="bg-muted text-primary inline-flex size-10 items-center justify-center rounded-full"
-        >
-          <Images className="size-5" aria-hidden="true" />
-        </span>
-        <span>
-          <strong class="font-heading block text-lg font-bold">
-            View all {images.length} photographs
-          </strong>
-          <span class="text-muted-foreground mt-0.5 block text-sm">
-            Portraits, workshop coverage, and downloadable event photographs
-          </span>
+      <span>
+        <strong class="font-heading block text-lg font-bold">
+          View all {images.length} photographs
+        </strong>
+        <span class="text-muted-foreground mt-1 block text-sm">
+          Portraits, workshop coverage, and downloadable event photographs
         </span>
       </span>
-      <span
-        class="text-muted-foreground shrink-0 text-2xl leading-none transition-transform group-open:rotate-45"
+      <ChevronDown
+        className="text-muted-foreground size-5 shrink-0 transition-transform group-open:rotate-180"
         aria-hidden="true"
-      >
-        +
-      </span>
+      />
     </summary>
 
     <div class="border-border border-t pt-6">

--- a/src/components/EventGallery.astro
+++ b/src/components/EventGallery.astro
@@ -125,59 +125,83 @@ const galleryId = `event-gallery-${heading
     )
   }
 
-  <div class="mt-10">
-    <div class="flex items-center gap-2">
-      <Images className="text-primary size-5" aria-hidden="true" />
-      <h3 class="font-heading text-lg font-bold">Full gallery</h3>
-    </div>
-    <div class="mt-4 columns-1 gap-4 sm:columns-2 lg:columns-3">
-      {
-        images.map((image, index) => (
-          <figure class="mb-4 break-inside-avoid">
-            <a
-              href={image.src}
-              class="group bg-muted focus-visible:ring-ring relative block overflow-hidden rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              data-gallery-open={index}
-              aria-label={`Open photograph ${index + 1}: ${image.alt}`}
-            >
-              <Image
-                src={image.src}
-                alt={image.alt}
-                width={image.width}
-                height={image.height}
-                layout="full-width"
-                widths={[480, 720, 960]}
-                sizes="(min-width: 1024px) 30vw, (min-width: 640px) 50vw, 100vw"
-                loading="lazy"
-                decoding="async"
-                class="block h-auto w-full transition-opacity duration-200 group-hover:opacity-90"
-              />
-            </a>
-            <div class="mt-2 flex items-start justify-between gap-3">
-              {image.caption ? (
-                <figcaption class="text-muted-foreground text-sm">
-                  {image.caption}
-                </figcaption>
-              ) : (
-                <span class="text-muted-foreground text-xs">
-                  {image.filename}
-                </span>
-              )}
+  <details class="group border-border mt-10 border-y">
+    <summary
+      class="focus-visible:ring-ring flex cursor-pointer list-none items-center justify-between gap-4 py-5 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset [&::-webkit-details-marker]:hidden"
+    >
+      <span class="flex items-center gap-3">
+        <span
+          class="bg-muted text-primary inline-flex size-10 items-center justify-center rounded-full"
+        >
+          <Images className="size-5" aria-hidden="true" />
+        </span>
+        <span>
+          <strong class="font-heading block text-lg font-bold">
+            View all {images.length} photographs
+          </strong>
+          <span class="text-muted-foreground mt-0.5 block text-sm">
+            Portraits, workshop coverage, and downloadable event photographs
+          </span>
+        </span>
+      </span>
+      <span
+        class="text-muted-foreground shrink-0 text-2xl leading-none transition-transform group-open:rotate-45"
+        aria-hidden="true"
+      >
+        +
+      </span>
+    </summary>
+
+    <div class="border-border border-t pt-6">
+      <div class="columns-1 gap-4 sm:columns-2 lg:columns-3">
+        {
+          images.map((image, index) => (
+            <figure class="mb-4 break-inside-avoid">
               <a
                 href={image.src}
-                download={image.filename}
-                data-gallery-download-file
-                data-filename={image.filename}
-                class="text-foreground hover:text-primary focus-visible:ring-ring inline-flex shrink-0 items-center gap-1 rounded-sm text-xs font-bold underline decoration-dotted underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
-                aria-label={`Download ${image.filename}`}
+                class="group/image bg-muted focus-visible:ring-ring relative block overflow-hidden rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                data-gallery-open={index}
+                aria-label={`Open photograph ${index + 1}: ${image.alt}`}
               >
-                <Download className="size-3.5" aria-hidden="true" />
-                Download
+                <Image
+                  src={image.src}
+                  alt={image.alt}
+                  width={image.width}
+                  height={image.height}
+                  layout="full-width"
+                  widths={[480, 720, 960]}
+                  sizes="(min-width: 1024px) 30vw, (min-width: 640px) 50vw, 100vw"
+                  loading="lazy"
+                  decoding="async"
+                  class="block h-auto w-full transition-opacity duration-200 group-hover/image:opacity-90"
+                />
               </a>
-            </div>
-          </figure>
-        ))
-      }
+              <div class="mt-2 flex items-start justify-between gap-3">
+                {image.caption ? (
+                  <figcaption class="text-muted-foreground text-sm">
+                    {image.caption}
+                  </figcaption>
+                ) : (
+                  <span class="text-muted-foreground text-xs">
+                    {image.filename}
+                  </span>
+                )}
+                <a
+                  href={image.src}
+                  download={image.filename}
+                  data-gallery-download-file
+                  data-filename={image.filename}
+                  class="text-foreground hover:text-primary focus-visible:ring-ring inline-flex shrink-0 items-center gap-1 rounded-sm text-xs font-bold underline decoration-dotted underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
+                  aria-label={`Download ${image.filename}`}
+                >
+                  <Download className="size-3.5" aria-hidden="true" />
+                  Download
+                </a>
+              </div>
+            </figure>
+          ))
+        }
+      </div>
     </div>
-  </div>
+  </details>
 </section>

--- a/src/components/EventGallery.astro
+++ b/src/components/EventGallery.astro
@@ -1,0 +1,183 @@
+---
+import { Image } from 'astro:assets'
+import { Download, Images } from 'lucide-react'
+import EventLightbox from './EventLightbox'
+
+type GalleryImage = {
+  src: string
+  width: number
+  height: number
+  alt: string
+  filename: string
+  caption?: string
+  featured?: boolean
+}
+
+type Props = {
+  images: GalleryImage[]
+  heading: string
+  description?: string
+  downloadAllUrl?: string
+}
+
+const { images, heading, description, downloadAllUrl } = Astro.props as Props
+const featuredImages = images.filter((image) => image.featured)
+const curatedImages =
+  featuredImages.length > 0 ? featuredImages : images.slice(0, 12)
+const galleryId = `event-gallery-${heading
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, '-')
+  .replace(/^-|-$/g, '')}`
+---
+
+<section
+  id={galleryId}
+  class="border-border mx-auto max-w-5xl border-t py-8 sm:py-10"
+  aria-labelledby={`${galleryId}-title`}
+>
+  <div class="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h2 id={`${galleryId}-title`} class="font-heading text-2xl font-bold">
+        {heading}
+      </h2>
+      {
+        description && (
+          <p class="text-muted-foreground mt-2 max-w-2xl text-sm leading-6 sm:text-base">
+            {description}
+          </p>
+        )
+      }
+      <p class="text-muted-foreground mt-2 text-sm">
+        {images.length}
+        {images.length === 1 ? 'photograph' : 'photographs'}
+      </p>
+    </div>
+
+    <EventLightbox
+      client:idle={{ timeout: 500 }}
+      galleryId={galleryId}
+      heading={heading}
+      images={images.map(({ src, filename, alt }) => ({ src, filename, alt }))}
+      downloadAllUrl={downloadAllUrl}
+    >
+      {
+        images.map((image, index) => (
+          <figure
+            class="m-0 flex h-full w-full flex-col items-center justify-center"
+            data-gallery-slide={index}
+            hidden={index !== 0}
+          >
+            <Image
+              src={image.src}
+              alt={image.alt}
+              width={image.width}
+              height={image.height}
+              layout="constrained"
+              widths={[960, 1440, 1920, 2400]}
+              sizes="100vw"
+              loading="lazy"
+              decoding="async"
+              class="max-h-[calc(100dvh-9rem)] w-auto max-w-full object-contain"
+            />
+            {(image.caption || image.filename) && (
+              <figcaption class="mt-3 max-w-3xl text-center text-sm text-white/75">
+                {image.caption ?? image.filename}
+              </figcaption>
+            )}
+          </figure>
+        ))
+      }
+    </EventLightbox>
+  </div>
+
+  {
+    curatedImages.length > 0 && (
+      <div class="mt-8">
+        <h3 class="font-heading text-lg font-bold">Selected photographs</h3>
+        <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {curatedImages.map((image) => {
+            const imageIndex = images.indexOf(image)
+
+            return (
+              <a
+                href={image.src}
+                class="group bg-muted focus-visible:ring-ring relative block overflow-hidden rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                data-gallery-open={imageIndex}
+                aria-label={`Open photograph ${imageIndex + 1}: ${image.alt}`}
+              >
+                <Image
+                  src={image.src}
+                  alt={image.alt}
+                  width={image.width}
+                  height={image.height}
+                  layout="constrained"
+                  widths={[480, 720, 960]}
+                  sizes="(min-width: 1024px) 30vw, (min-width: 640px) 50vw, 100vw"
+                  loading="lazy"
+                  decoding="async"
+                  class="aspect-[3/2] size-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+                />
+              </a>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+
+  <div class="mt-10">
+    <div class="flex items-center gap-2">
+      <Images className="text-primary size-5" aria-hidden="true" />
+      <h3 class="font-heading text-lg font-bold">Full gallery</h3>
+    </div>
+    <div class="mt-4 columns-1 gap-4 sm:columns-2 lg:columns-3">
+      {
+        images.map((image, index) => (
+          <figure class="mb-4 break-inside-avoid">
+            <a
+              href={image.src}
+              class="group bg-muted focus-visible:ring-ring relative block overflow-hidden rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              data-gallery-open={index}
+              aria-label={`Open photograph ${index + 1}: ${image.alt}`}
+            >
+              <Image
+                src={image.src}
+                alt={image.alt}
+                width={image.width}
+                height={image.height}
+                layout="full-width"
+                widths={[480, 720, 960]}
+                sizes="(min-width: 1024px) 30vw, (min-width: 640px) 50vw, 100vw"
+                loading="lazy"
+                decoding="async"
+                class="block h-auto w-full transition-opacity duration-200 group-hover:opacity-90"
+              />
+            </a>
+            <div class="mt-2 flex items-start justify-between gap-3">
+              {image.caption ? (
+                <figcaption class="text-muted-foreground text-sm">
+                  {image.caption}
+                </figcaption>
+              ) : (
+                <span class="text-muted-foreground text-xs">
+                  {image.filename}
+                </span>
+              )}
+              <a
+                href={image.src}
+                download={image.filename}
+                data-gallery-download-file
+                data-filename={image.filename}
+                class="text-foreground hover:text-primary focus-visible:ring-ring inline-flex shrink-0 items-center gap-1 rounded-sm text-xs font-bold underline decoration-dotted underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
+                aria-label={`Download ${image.filename}`}
+              >
+                <Download className="size-3.5" aria-hidden="true" />
+                Download
+              </a>
+            </div>
+          </figure>
+        ))
+      }
+    </div>
+  </div>
+</section>

--- a/src/components/EventLightbox.tsx
+++ b/src/components/EventLightbox.tsx
@@ -1,0 +1,209 @@
+import * as React from 'react'
+import { ChevronLeft, ChevronRight, Download, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+type GalleryImage = {
+  src: string
+  filename: string
+  alt: string
+}
+
+type EventLightboxProps = {
+  galleryId: string
+  heading: string
+  images: GalleryImage[]
+  downloadAllUrl?: string
+  children: React.ReactNode
+}
+
+async function downloadFile(url: string, filename: string) {
+  try {
+    const response = await fetch(url, { mode: 'cors' })
+    if (!response.ok) throw new Error(`Download failed: ${response.status}`)
+
+    const objectUrl = URL.createObjectURL(await response.blob())
+    const anchor = document.createElement('a')
+    anchor.href = objectUrl
+    anchor.download = filename
+    document.body.append(anchor)
+    anchor.click()
+    anchor.remove()
+    URL.revokeObjectURL(objectUrl)
+  } catch {
+    window.open(url, '_blank', 'noopener,noreferrer')
+  }
+}
+
+export default function EventLightbox({
+  galleryId,
+  heading,
+  images,
+  downloadAllUrl,
+  children,
+}: EventLightboxProps) {
+  const [open, setOpen] = React.useState(false)
+  const [currentIndex, setCurrentIndex] = React.useState(0)
+  const slidesRef = React.useRef<HTMLDivElement>(null)
+  const lastFocusedRef = React.useRef<HTMLElement | null>(null)
+  const wasOpenRef = React.useRef(false)
+
+  const showSlide = React.useCallback(
+    (nextIndex: number) => {
+      if (images.length === 0) return
+      setCurrentIndex((nextIndex + images.length) % images.length)
+    },
+    [images.length],
+  )
+
+  React.useEffect(() => {
+    const slides = slidesRef.current?.querySelectorAll<HTMLElement>(
+      '[data-gallery-slide]',
+    )
+    slides?.forEach((slide, index) => {
+      slide.hidden = index !== currentIndex
+    })
+  }, [currentIndex, open])
+
+  React.useEffect(() => {
+    const gallery = document.getElementById(galleryId)
+    if (!gallery) return
+
+    const handleClick = async (event: MouseEvent) => {
+      const target = event.target as Element
+      const opener = target.closest<HTMLAnchorElement>('[data-gallery-open]')
+
+      if (opener) {
+        event.preventDefault()
+        lastFocusedRef.current = opener
+        showSlide(Number(opener.dataset.galleryOpen ?? 0))
+        setOpen(true)
+        return
+      }
+
+      const download = target.closest<HTMLAnchorElement>(
+        '[data-gallery-download-file]',
+      )
+      if (!download) return
+
+      event.preventDefault()
+      const filename =
+        download.dataset.filename || download.download || 'photograph.jpg'
+      download.setAttribute('aria-busy', 'true')
+      await downloadFile(download.href, filename)
+      download.removeAttribute('aria-busy')
+    }
+
+    gallery.addEventListener('click', handleClick)
+    return () => gallery.removeEventListener('click', handleClick)
+  }, [galleryId, showSlide])
+
+  React.useEffect(() => {
+    if (wasOpenRef.current && !open) {
+      lastFocusedRef.current?.focus()
+    }
+    wasOpenRef.current = open
+  }, [open])
+
+  const currentImage = images[currentIndex]
+
+  return (
+    <>
+      {downloadAllUrl && (
+        <Button asChild size="lg">
+          <a href={downloadAllUrl} download>
+            <Download data-icon="inline-start" aria-hidden="true" />
+            Download all
+          </a>
+        </Button>
+      )}
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          showCloseButton={false}
+          className="flex h-dvh max-h-none w-screen max-w-none flex-col gap-0 rounded-none bg-black p-0 text-white shadow-none ring-0 sm:max-w-none"
+          onKeyDown={(event) => {
+            if (event.key === 'ArrowLeft') showSlide(currentIndex - 1)
+            if (event.key === 'ArrowRight') showSlide(currentIndex + 1)
+          }}
+        >
+          <DialogTitle className="sr-only">
+            {heading} photograph viewer
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Use the previous and next buttons or the left and right arrow keys
+            to browse the gallery.
+          </DialogDescription>
+
+          <div className="flex h-full min-h-0 flex-1 flex-col">
+            <div className="flex items-center justify-between gap-4 px-4 py-3 sm:px-6">
+              <p className="text-sm font-semibold" aria-live="polite">
+                Photograph {currentIndex + 1} of {images.length}
+              </p>
+              <div className="flex items-center gap-2">
+                {currentImage && (
+                  <Button
+                    variant="secondary"
+                    onClick={() =>
+                      downloadFile(currentImage.src, currentImage.filename)
+                    }
+                  >
+                    <Download data-icon="inline-start" aria-hidden="true" />
+                    Download
+                  </Button>
+                )}
+                <DialogClose asChild>
+                  <Button
+                    variant="secondary"
+                    size="icon"
+                    aria-label="Close photograph viewer"
+                  >
+                    <X aria-hidden="true" />
+                  </Button>
+                </DialogClose>
+              </div>
+            </div>
+
+            <div className="relative flex min-h-0 flex-1 items-center justify-center px-14 py-4 sm:px-20">
+              <Button
+                type="button"
+                variant="secondary"
+                size="icon-lg"
+                className="absolute left-2 sm:left-5"
+                onClick={() => showSlide(currentIndex - 1)}
+                aria-label="Previous photograph"
+              >
+                <ChevronLeft aria-hidden="true" />
+              </Button>
+
+              <div
+                ref={slidesRef}
+                className="flex h-full min-h-0 w-full items-center justify-center"
+              >
+                {children}
+              </div>
+
+              <Button
+                type="button"
+                variant="secondary"
+                size="icon-lg"
+                className="absolute right-2 sm:right-5"
+                onClick={() => showSlide(currentIndex + 1)}
+                aria-label="Next photograph"
+              >
+                <ChevronRight aria-hidden="true" />
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/PortfolioIndex.astro
+++ b/src/components/PortfolioIndex.astro
@@ -20,7 +20,7 @@ type PortfolioCard = {
   slug: string
   title: string
   category: string
-  thumbnail: ImageMetadata
+  thumbnail: ImageMetadata | string
   imageAlt: string
   imageWidth: number
   imageHeight: number
@@ -209,18 +209,33 @@ const socialColumns = [
               href={`/portfolio/${project.slug}/`}
               class="group focus-visible:ring-ring block rounded-sm focus-visible:ring-2 focus-visible:ring-offset-4 focus-visible:outline-none"
             >
-              <Image
-                src={project.thumbnail}
-                alt={project.imageAlt}
-                width={project.imageWidth}
-                height={project.imageHeight}
-                layout="constrained"
-                widths={[480, 720, 960]}
-                sizes="(min-width: 1280px) 30vw, (min-width: 768px) 48vw, 100vw"
-                quality={80}
-                priority={index === 0}
-                class="bg-muted block h-auto w-full transition-opacity duration-200 group-hover:opacity-90"
-              />
+              {typeof project.thumbnail === 'string' ? (
+                <Image
+                  src={project.thumbnail}
+                  alt={project.imageAlt}
+                  width={project.imageWidth}
+                  height={project.imageHeight}
+                  layout="constrained"
+                  widths={[480, 720, 960]}
+                  sizes="(min-width: 1280px) 30vw, (min-width: 768px) 48vw, 100vw"
+                  quality={80}
+                  priority={index === 0}
+                  class="bg-muted block h-auto w-full transition-opacity duration-200 group-hover:opacity-90"
+                />
+              ) : (
+                <Image
+                  src={project.thumbnail}
+                  alt={project.imageAlt}
+                  width={project.imageWidth}
+                  height={project.imageHeight}
+                  layout="constrained"
+                  widths={[480, 720, 960]}
+                  sizes="(min-width: 1280px) 30vw, (min-width: 768px) 48vw, 100vw"
+                  quality={80}
+                  priority={index === 0}
+                  class="bg-muted block h-auto w-full transition-opacity duration-200 group-hover:opacity-90"
+                />
+              )}
               <span class="mt-3 block">
                 <strong class="font-heading text-foreground block text-base leading-5 font-extrabold">
                   {project.title}

--- a/src/components/UpcomingVideo.tsx
+++ b/src/components/UpcomingVideo.tsx
@@ -1,0 +1,57 @@
+import { Film, Play } from 'lucide-react'
+
+import { Skeleton } from '@/components/ui/skeleton'
+
+type UpcomingVideoProps = {
+  label: string
+  title: string
+  description: string
+}
+
+export default function UpcomingVideo({
+  label,
+  title,
+  description,
+}: UpcomingVideoProps) {
+  return (
+    <section
+      className="border-border mx-auto max-w-4xl border-t py-8 sm:py-10"
+      aria-labelledby="upcoming-video-title"
+    >
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.45fr)_minmax(15rem,0.55fr)] lg:items-center">
+        <div
+          className="border-border bg-muted/40 relative aspect-video overflow-hidden rounded-2xl border"
+          aria-hidden="true"
+        >
+          <Skeleton className="absolute inset-0 rounded-none" />
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className="bg-background text-foreground inline-flex size-14 items-center justify-center rounded-full shadow-sm">
+              <Film aria-hidden="true" />
+            </span>
+          </div>
+          <div className="absolute right-4 bottom-4 left-4 space-y-2">
+            <Skeleton className="bg-background/70 h-3 w-2/3" />
+            <Skeleton className="bg-background/70 h-3 w-1/3" />
+          </div>
+        </div>
+
+        <div>
+          <p className="text-primary text-xs font-bold tracking-wider uppercase">
+            {label}
+          </p>
+          <h2
+            id="upcoming-video-title"
+            className="font-heading mt-2 text-2xl font-bold"
+          >
+            {title}
+          </h2>
+          <p className="text-muted-foreground mt-3 leading-7">{description}</p>
+          <p className="mt-5 flex items-center gap-2 text-sm font-bold">
+            <Play data-icon="inline-start" aria-hidden="true" />
+            YouTube release coming soon
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/YouTubeEmbed.astro
+++ b/src/components/YouTubeEmbed.astro
@@ -6,7 +6,7 @@ type Props = {
   youtubeId: string
   title: string
   autoplay?: boolean
-  poster?: ImageMetadata
+  poster?: ImageMetadata | string
   posterAlt?: string
   class?: string
 }
@@ -19,6 +19,8 @@ const {
   posterAlt = '',
   class: className,
 } = Astro.props
+const remotePoster = typeof poster === 'string' ? poster : undefined
+const localPoster = typeof poster === 'string' ? undefined : poster
 ---
 
 <div
@@ -32,9 +34,9 @@ const {
   data-youtube-autoplay={autoplay ? 'true' : 'false'}
 >
   {
-    poster && (
+    remotePoster ? (
       <Image
-        src={poster}
+        src={remotePoster}
         alt={posterAlt}
         width={1280}
         height={720}
@@ -46,7 +48,21 @@ const {
         class="absolute inset-0 size-full object-cover"
         data-youtube-poster
       />
-    )
+    ) : localPoster ? (
+      <Image
+        src={localPoster}
+        alt={posterAlt}
+        width={1280}
+        height={720}
+        layout="full-width"
+        widths={[640, 960, 1280]}
+        sizes="(min-width: 1280px) 1216px, 100vw"
+        quality={80}
+        priority
+        class="absolute inset-0 size-full object-cover"
+        data-youtube-poster
+      />
+    ) : null
   }
   <div
     class="absolute inset-0 flex items-center justify-center"

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,165 @@
+import * as React from 'react'
+import { Dialog as DialogPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { XIcon } from 'lucide-react'
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 isolate z-50 bg-black/30 duration-100 supports-backdrop-filter:backdrop-blur-sm',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'bg-popover text-popover-foreground ring-foreground/5 dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-[min(var(--radius-4xl),24px)] p-6 text-sm shadow-xl ring-1 duration-100 outline-none sm:max-w-md',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button
+              variant="ghost"
+              className="bg-secondary absolute top-4 right-4"
+              size="icon-sm"
+            >
+              <XIcon data-icon="inline-start" />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-1.5', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        'font-heading text-base leading-none font-medium',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        'text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('bg-muted animate-pulse rounded-2xl', className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -24,6 +24,12 @@ const portfolioVideo = z.object({
   comparisonRole: z.enum(['before', 'after']).optional(),
 })
 
+const upcomingPortfolioVideo = z.object({
+  label: z.string(),
+  title: z.string(),
+  description: z.string(),
+})
+
 const portfolio = defineCollection({
   loader: glob({
     base: './src/content/portfolio',
@@ -31,11 +37,22 @@ const portfolio = defineCollection({
   }),
   schema: ({ image }) => {
     const portfolioAsset = image()
-    const portfolioImage = z.object({
+    const localPortfolioImage = z.object({
       src: portfolioAsset,
       alt: z.string(),
       caption: z.string().optional(),
     })
+    const remotePortfolioImage = z.object({
+      src: z.url(),
+      width: z.number().int().positive(),
+      height: z.number().int().positive(),
+      alt: z.string(),
+      filename: z.string().min(1),
+      caption: z.string().optional(),
+      featured: z.boolean().default(false),
+    })
+    const portfolioImage = z.union([remotePortfolioImage, localPortfolioImage])
+    const portfolioHeroAsset = z.union([remotePortfolioImage, portfolioAsset])
 
     return z.object({
       order: z.number().int().nonnegative(),
@@ -45,8 +62,8 @@ const portfolio = defineCollection({
       status: z.enum(['complete', 'placeholder']),
       category: z.string(),
       summary: z.string(),
-      thumbnail: portfolioAsset,
-      heroImage: portfolioAsset,
+      thumbnail: portfolioHeroAsset,
+      heroImage: portfolioHeroAsset,
       heroVideo: z.string().optional(),
       imageAlt: z.string(),
       imageWidth: z.number().int().positive(),
@@ -61,8 +78,12 @@ const portfolio = defineCollection({
       outcomes: z.array(z.string()).default([]),
       galleryHeading: z.string().optional(),
       galleryLayout: z.enum(['stack', 'masonry']).default('stack'),
+      eventGallery: z.boolean().default(false),
+      galleryDescription: z.string().optional(),
+      downloadAllUrl: z.url().optional(),
       gallery: z.array(portfolioImage).default([]),
       videos: z.array(portfolioVideo).default([]),
+      upcomingVideo: upcomingPortfolioVideo.optional(),
     })
   },
 })

--- a/src/content/portfolio/EVENT_GALLERY_TEMPLATE.mdx.example
+++ b/src/content/portfolio/EVENT_GALLERY_TEMPLATE.mdx.example
@@ -1,0 +1,44 @@
+---
+order: 0
+title: Event title
+seoTitle: Event Photography in Tampa | Ayoub Abedrabbo
+seoDescription: Event photography and attendee portraits by Ayoub Abedrabbo.
+status: complete
+category: Event photography
+summary: A concise summary of the event, client, and photography assignment.
+thumbnail:
+  src: https://photos.ayoubabed.xyz/events/event-slug/images/featured.jpg
+  width: 2400
+  height: 1600
+  alt: Featured photograph from the event
+  filename: featured.jpg
+  featured: true
+heroImage:
+  src: https://photos.ayoubabed.xyz/events/event-slug/images/featured.jpg
+  width: 2400
+  height: 1600
+  alt: Featured photograph from the event
+  filename: featured.jpg
+  featured: true
+imageAlt: Featured photograph from the event
+imageWidth: 2400
+imageHeight: 1600
+services:
+  - Event photography
+  - Attendee portraits
+role: Event photographer and videographer
+galleryHeading: Event photographs
+galleryDescription: Select a photograph to view it larger or download a web-ready copy.
+galleryLayout: masonry
+eventGallery: true
+downloadAllUrl: https://photos.ayoubabed.xyz/events/event-slug/downloads/event-slug.zip
+gallery: []
+---
+
+## Overview
+
+Add the project story here. Generate the `gallery` entries with:
+
+```bash
+npm run gallery:manifest -- "C:\path\to\exports" "https://photos.ayoubabed.xyz/events/event-slug/images/" --output gallery.yml
+```

--- a/src/content/portfolio/muslim-business-chamber-2026.mdx
+++ b/src/content/portfolio/muslim-business-chamber-2026.mdx
@@ -1,0 +1,1060 @@
+---
+order: 0
+title: 'Muslim Chamber of Commerce USA: AI for Small Business'
+seoTitle: Muslim Chamber of Commerce USA Event Photography | Tampa
+seoDescription: Event photography, attendee portraits, lecture recording, and video coverage for the Muslim Chamber of Commerce USA workshop on using AI to grow a small business in Tampa.
+status: complete
+category: Event photography and video
+summary: Photography, attendee portraits, and lecture video coverage for a Tampa workshop helping small-business owners use AI to improve operations, customer experience, and revenue.
+thumbnail:
+  src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290896.jpg
+  width: 2400
+  height: 1600
+  alt: A presenter speaking to attendees during the Muslim Chamber of Commerce USA AI workshop
+  filename: P1290896.jpg
+  featured: true
+heroImage:
+  src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290896.jpg
+  width: 2400
+  height: 1600
+  alt: A presenter speaking to attendees during the Muslim Chamber of Commerce USA AI workshop
+  filename: P1290896.jpg
+  featured: true
+imageAlt: A presenter speaking to attendees during the Muslim Chamber of Commerce USA AI workshop
+imageWidth: 2400
+imageHeight: 1600
+services:
+  - Event photography
+  - Attendee portraits and headshots
+  - Full lecture video recording
+  - Event video production
+role: Event photographer and videographer
+duration: June 20, 2026
+outcomes:
+  - Delivered a complete 167-photograph attendee gallery
+  - Created professional attendee portraits and headshots during the workshop
+  - Recorded the full educational lecture for the organization
+  - Captured additional footage for an upcoming YouTube event video
+galleryHeading: Workshop photographs
+galleryDescription: Browse all 167 approved event photographs, open an image full screen, or download a web-ready copy.
+galleryLayout: masonry
+eventGallery: true
+downloadAllUrl: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/downloads/muslim-business-chamber-2026.zip
+gallery:
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290863.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 1
+    filename: P1290863.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290864.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 2
+    filename: P1290864.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290865.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 3
+    filename: P1290865.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290866.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 4
+    filename: P1290866.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290867.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 5
+    filename: P1290867.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290868.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 6
+    filename: P1290868.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290869.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 7
+    filename: P1290869.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290870.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 8
+    filename: P1290870.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290871.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 9
+    filename: P1290871.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290872.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 10
+    filename: P1290872.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290873.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 11
+    filename: P1290873.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290874.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 12
+    filename: P1290874.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290875.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 13
+    filename: P1290875.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290876.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 14
+    filename: P1290876.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290877.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 15
+    filename: P1290877.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290878.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 16
+    filename: P1290878.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290879.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 17
+    filename: P1290879.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290880.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 18
+    filename: P1290880.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290881.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 19
+    filename: P1290881.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290882.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 20
+    filename: P1290882.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290883.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 21
+    filename: P1290883.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290884.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 22
+    filename: P1290884.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290885.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 23
+    filename: P1290885.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290886.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 24
+    filename: P1290886.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290887.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 25
+    filename: P1290887.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290888.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 26
+    filename: P1290888.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290889.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 27
+    filename: P1290889.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290890.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 28
+    filename: P1290890.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290891.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 29
+    filename: P1290891.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290892.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 30
+    filename: P1290892.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290893.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 31
+    filename: P1290893.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290894.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 32
+    filename: P1290894.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290895.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 33
+    filename: P1290895.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290896.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 34
+    filename: P1290896.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290897.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 35
+    filename: P1290897.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290898.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 36
+    filename: P1290898.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290899.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 37
+    filename: P1290899.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290900.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 38
+    filename: P1290900.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290901.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 39
+    filename: P1290901.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290902.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 40
+    filename: P1290902.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290904.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 41
+    filename: P1290904.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290905.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 42
+    filename: P1290905.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290906.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 43
+    filename: P1290906.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290907.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 44
+    filename: P1290907.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290908.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 45
+    filename: P1290908.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290909.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 46
+    filename: P1290909.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290910.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 47
+    filename: P1290910.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290911.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 48
+    filename: P1290911.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290912.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 49
+    filename: P1290912.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290913.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 50
+    filename: P1290913.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290914.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 51
+    filename: P1290914.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290915.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 52
+    filename: P1290915.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290916.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 53
+    filename: P1290916.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290917.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 54
+    filename: P1290917.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290918.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 55
+    filename: P1290918.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290919.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 56
+    filename: P1290919.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290920.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 57
+    filename: P1290920.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290921.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 58
+    filename: P1290921.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290922.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 59
+    filename: P1290922.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290923.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 60
+    filename: P1290923.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290924.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 61
+    filename: P1290924.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290925.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 62
+    filename: P1290925.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290926.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 63
+    filename: P1290926.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290927.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 64
+    filename: P1290927.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290928.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 65
+    filename: P1290928.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290929.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 66
+    filename: P1290929.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290930.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 67
+    filename: P1290930.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290931.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 68
+    filename: P1290931.jpg
+    featured: true
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290932.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 69
+    filename: P1290932.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290933.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 70
+    filename: P1290933.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290934.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 71
+    filename: P1290934.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290935.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 72
+    filename: P1290935.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290936.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 73
+    filename: P1290936.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290937.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 74
+    filename: P1290937.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290938.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 75
+    filename: P1290938.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290939.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 76
+    filename: P1290939.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290940.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 77
+    filename: P1290940.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290941.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 78
+    filename: P1290941.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290942.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 79
+    filename: P1290942.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290943.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 80
+    filename: P1290943.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290944.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 81
+    filename: P1290944.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290945.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 82
+    filename: P1290945.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290946.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 83
+    filename: P1290946.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290947.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 84
+    filename: P1290947.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290948.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 85
+    filename: P1290948.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290949.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 86
+    filename: P1290949.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290950.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 87
+    filename: P1290950.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290951.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 88
+    filename: P1290951.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290952.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 89
+    filename: P1290952.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290953.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 90
+    filename: P1290953.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290954.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 91
+    filename: P1290954.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290955.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 92
+    filename: P1290955.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290956.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 93
+    filename: P1290956.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290957.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 94
+    filename: P1290957.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290958.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 95
+    filename: P1290958.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290959.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 96
+    filename: P1290959.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290960.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 97
+    filename: P1290960.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290961.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 98
+    filename: P1290961.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290962.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 99
+    filename: P1290962.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290963.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 100
+    filename: P1290963.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290964.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 101
+    filename: P1290964.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290965.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 102
+    filename: P1290965.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290966.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 103
+    filename: P1290966.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290967.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 104
+    filename: P1290967.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290968.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 105
+    filename: P1290968.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290969.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 106
+    filename: P1290969.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290970.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 107
+    filename: P1290970.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290971.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 108
+    filename: P1290971.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290972.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 109
+    filename: P1290972.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290973.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 110
+    filename: P1290973.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290974.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 111
+    filename: P1290974.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290975.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 112
+    filename: P1290975.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290976.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 113
+    filename: P1290976.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290977.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 114
+    filename: P1290977.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290978.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 115
+    filename: P1290978.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290979.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 116
+    filename: P1290979.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290980.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 117
+    filename: P1290980.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290981.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 118
+    filename: P1290981.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290982.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 119
+    filename: P1290982.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290983.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 120
+    filename: P1290983.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290984.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 121
+    filename: P1290984.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290985.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 122
+    filename: P1290985.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290986.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 123
+    filename: P1290986.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290987.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 124
+    filename: P1290987.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290988.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 125
+    filename: P1290988.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290989.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 126
+    filename: P1290989.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290990.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 127
+    filename: P1290990.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290991.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 128
+    filename: P1290991.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290992.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 129
+    filename: P1290992.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290993.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 130
+    filename: P1290993.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290994.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 131
+    filename: P1290994.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290995.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 132
+    filename: P1290995.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290996.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 133
+    filename: P1290996.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290997.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 134
+    filename: P1290997.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290998.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 135
+    filename: P1290998.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1290999.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 136
+    filename: P1290999.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291000.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 137
+    filename: P1291000.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291001.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 138
+    filename: P1291001.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291002.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 139
+    filename: P1291002.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291003.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 140
+    filename: P1291003.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291004.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 141
+    filename: P1291004.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291005.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 142
+    filename: P1291005.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291006.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 143
+    filename: P1291006.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291007.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 144
+    filename: P1291007.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291008.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 145
+    filename: P1291008.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291009.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 146
+    filename: P1291009.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291010.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 147
+    filename: P1291010.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291011.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 148
+    filename: P1291011.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291012.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 149
+    filename: P1291012.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291013.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 150
+    filename: P1291013.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291014.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 151
+    filename: P1291014.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291015.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 152
+    filename: P1291015.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291016.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 153
+    filename: P1291016.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291017.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 154
+    filename: P1291017.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291018.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 155
+    filename: P1291018.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291019.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 156
+    filename: P1291019.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291020.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 157
+    filename: P1291020.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291021.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 158
+    filename: P1291021.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291022.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 159
+    filename: P1291022.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291023.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 160
+    filename: P1291023.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291024.jpg
+    width: 1600
+    height: 2400
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 161
+    filename: P1291024.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291027.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 162
+    filename: P1291027.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291028.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 163
+    filename: P1291028.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291030.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 164
+    filename: P1291030.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291031.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 165
+    filename: P1291031.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291032.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 166
+    filename: P1291032.jpg
+    featured: false
+  - src: https://photos.ayoubabed.xyz/events/muslim-business-chamber-2026/images/P1291033.jpg
+    width: 2400
+    height: 1600
+    alt: Muslim Chamber of Commerce USA AI workshop photograph 167
+    filename: P1291033.jpg
+    featured: false
+upcomingVideo:
+  label: Event video in production
+  title: Lecture recording and event film
+  description: I recorded the full workshop lecture and captured additional event footage. A finished YouTube video about the event is now in production and will be added here when it is released.
+---
+
+## Using AI to Drive Growth in Your Small Business
+
+The Muslim Chamber of Commerce USA hosted this interactive workshop for Tampa Bay business owners, entrepreneurs, and professionals interested in applying artificial intelligence to practical business challenges.
+
+The program focused on using AI-powered tools to optimize operations, improve customer experiences, and identify new revenue opportunities. I provided event photography, attendee portraits and headshots, full lecture recording, and additional video coverage throughout the workshop.
+
+The event took place on Saturday, June 20, 2026, at the Lesley ?Les? Miller Jr. Park amphitheater area in Tampa, Florida.
+
+The complete photography gallery is available below. The recorded lecture and a finished YouTube event video will be added when post-production is complete.

--- a/src/content/portfolio/muslim-business-chamber-2026.mdx
+++ b/src/content/portfolio/muslim-business-chamber-2026.mdx
@@ -28,13 +28,20 @@ services:
   - Attendee portraits and headshots
   - Full lecture video recording
   - Event video production
-role: Event photographer and videographer
+  - Event experience consulting
+  - Anonymous attendee feedback setup
+  - Presentation and screen technical support
+  - Speaker timing support
+role: Event photographer, videographer, and event experience consultant
 duration: June 20, 2026
 outcomes:
   - Delivered a complete 167-photograph attendee gallery
   - Created professional attendee portraits and headshots during the workshop
   - Recorded the full educational lecture for the organization
   - Captured additional footage for an upcoming YouTube event video
+  - Set up an anonymous Google Forms feedback process for attendees
+  - Supported presenters with screens, content sharing, and technical troubleshooting
+  - Helped presentations stay aligned with the event schedule
 galleryHeading: Workshop photographs
 galleryDescription: Browse all 167 approved event photographs, open an image full screen, or download a web-ready copy.
 galleryLayout: masonry
@@ -1055,6 +1062,18 @@ The Muslim Chamber of Commerce USA hosted this interactive workshop for Tampa Ba
 
 The program focused on using AI-powered tools to optimize operations, improve customer experiences, and identify new revenue opportunities. I provided event photography, attendee portraits and headshots, full lecture recording, and additional video coverage throughout the workshop.
 
-The event took place on Saturday, June 20, 2026, at the Lesley ?Les? Miller Jr. Park amphitheater area in Tampa, Florida.
+The event took place on Saturday, June 20, 2026, at the Lesley "Les" Miller Jr. Park amphitheater area in Tampa, Florida.
+
+## Event experience and technical support
+
+My role extended beyond photography and video. I consulted with the organizers on ways to improve the attendee experience, created an anonymous Google Forms feedback process, helped presenters connect and share content on the event screens, handled technical troubleshooting, and supported the schedule so guest presentations stayed on time.
+
+I also bring practical audio engineering and small-event AV experience. I can set up speakers, mixing boards, and wireless microphone systems, including Shure and similar equipment, and configure signal routing, equalization, compression, reverb, and delay. I am continuing to expand these capabilities toward a more complete event service that can bring photography, video, presentation support, and reliable sound together.
+
+## Recommendations for future events
+
+Following the workshop, I developed recommendations for the next event: stronger sound reinforcement, wireless microphones, direct microphone recording for presentation videos, a visible countdown timer for speakers, presentation coaching, and a deliberate feedback process for measuring and improving the attendee experience.
+
+My approach is detail-focused and guest-centered. Whether I am monitoring a presentation, solving a technical problem, recording a speaker, or photographing an attendee, the goal is the same: create a smooth experience for the organizers and guests and help make the event memorable.
 
 The complete photography gallery is available below. The recorded lecture and a finished YouTube event video will be added when post-production is complete.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,15 +35,24 @@ const supportLinks = actionLinks.filter((link) => link.group === 'support')
 const sameAsUrls = socialLinks.map((link) => link.url)
 const portfolioProjects = (await getCollection('portfolio'))
   .sort((a, b) => a.data.order - b.data.order)
-  .map((entry) => ({
-    slug: entry.id,
-    title: entry.data.title,
-    category: entry.data.category,
-    thumbnail: entry.data.thumbnail as ImageMetadata,
-    imageAlt: entry.data.imageAlt,
-    imageWidth: entry.data.imageWidth,
-    imageHeight: entry.data.imageHeight,
-  }))
+  .map((entry) => {
+    const thumbnail = entry.data.thumbnail
+
+    return {
+      slug: entry.id,
+      title: entry.data.title,
+      category: entry.data.category,
+      thumbnail:
+        typeof thumbnail === 'object' &&
+        thumbnail !== null &&
+        'filename' in thumbnail
+          ? thumbnail.src
+          : (thumbnail as ImageMetadata | string),
+      imageAlt: entry.data.imageAlt,
+      imageWidth: entry.data.imageWidth,
+      imageHeight: entry.data.imageHeight,
+    }
+  })
 
 const structuredData = {
   '@context': 'https://schema.org',

--- a/src/pages/portfolio/[slug].astro
+++ b/src/pages/portfolio/[slug].astro
@@ -5,7 +5,9 @@ import type { ImageMetadata } from 'astro'
 import { Image } from 'astro:assets'
 import { getCollection, render, type CollectionEntry } from 'astro:content'
 import { ArrowLeft, ArrowRight, ArrowUpRight, Play } from 'lucide-react'
+import EventGallery from '../../components/EventGallery.astro'
 import PortfolioLocation from '../../components/PortfolioLocation.astro'
+import UpcomingVideo from '../../components/UpcomingVideo'
 import YouTubeEmbed from '../../components/YouTubeEmbed.astro'
 
 export async function getStaticPaths() {
@@ -44,14 +46,35 @@ type Props = {
 const { project, previousProject, nextProject } = Astro.props as Props
 const { Content } = await render(project)
 const projectData = project.data
-const heroImage = projectData.heroImage as ImageMetadata
-const galleryImages = projectData.gallery.map((image) => ({
-  ...image,
-  src: image.src as ImageMetadata,
-}))
+const heroImageAsset = projectData.heroImage
+const heroImage =
+  typeof heroImageAsset === 'object' &&
+  heroImageAsset !== null &&
+  'filename' in heroImageAsset
+    ? heroImageAsset.src
+    : (heroImageAsset as ImageMetadata | string)
+const remoteGalleryImages = projectData.eventGallery
+  ? projectData.gallery.filter(
+      (
+        image,
+      ): image is Extract<
+        (typeof projectData.gallery)[number],
+        { filename: string }
+      > => 'filename' in image,
+    )
+  : []
+const galleryImages = projectData.eventGallery
+  ? []
+  : projectData.gallery.map((image) => ({
+      ...image,
+      src: image.src as ImageMetadata,
+    }))
 const hasBody = Boolean(project.body?.trim())
 const canonicalUrl = new URL(`/portfolio/${project.id}/`, Astro.site).toString()
-const socialImageUrl = new URL(heroImage.src, Astro.site).toString()
+const socialImageUrl =
+  typeof heroImage === 'string'
+    ? heroImage
+    : new URL(heroImage.src, Astro.site).toString()
 const projectTitle =
   projectData.seoTitle ?? `${projectData.title} - Ayoub Abedrabbo`
 const projectDescription = projectData.seoDescription ?? projectData.summary
@@ -196,6 +219,19 @@ const galleryHeading =
               title={`${projectData.title} featured video`}
               poster={heroImage}
               posterAlt={projectData.imageAlt}
+            />
+          ) : typeof heroImage === 'string' ? (
+            <Image
+              src={heroImage}
+              alt={projectData.imageAlt}
+              width={projectData.imageWidth}
+              height={projectData.imageHeight}
+              layout="full-width"
+              widths={[640, 960, 1280, 1600]}
+              sizes="(min-width: 1280px) 1216px, 100vw"
+              quality={82}
+              priority
+              class="bg-muted block h-auto w-full"
             />
           ) : (
             <Image
@@ -466,6 +502,12 @@ const galleryHeading =
         }
 
         {
+          projectData.upcomingVideo && (
+            <UpcomingVideo {...projectData.upcomingVideo} />
+          )
+        }
+
+        {
           projectData.outcomes.length > 0 && (
             <section
               class="border-border mx-auto max-w-4xl border-t py-8 sm:py-10"
@@ -486,7 +528,14 @@ const galleryHeading =
         }
 
         {
-          galleryImages.length > 0 && (
+          projectData.eventGallery && remoteGalleryImages.length > 0 ? (
+            <EventGallery
+              images={remoteGalleryImages}
+              heading={galleryHeading}
+              description={projectData.galleryDescription}
+              downloadAllUrl={projectData.downloadAllUrl}
+            />
+          ) : galleryImages.length > 0 ? (
             <section
               class="border-border mx-auto max-w-4xl border-t py-8 sm:py-10"
               aria-labelledby="gallery-title"
@@ -609,7 +658,7 @@ const galleryHeading =
                 </div>
               )}
             </section>
-          )
+          ) : null
         }
 
         {


### PR DESCRIPTION
## Summary
- add reusable Cloudflare R2-backed event galleries with Astro Image rendering
- add an accessible shadcn/Radix lightbox, downloads, and collapsible full-gallery disclosure
- add the Muslim Chamber of Commerce USA AI workshop portfolio with 167 photographs
- document photography, lecture recording, event consulting, technical support, and upcoming video production
- add manifest generation and R2 gallery configuration documentation

## Validation
- npm run check
- npm run build
- verified R2 hero image and ZIP return HTTP 200 with immutable cache headers
- verified the ZIP uses an attachment filename
