### PR TITLE
Add Sanad wedding gallery page and remote event images

### DIFF
--- a/src/components/EventGallery.astro
+++ b/src/components/EventGallery.astro
@@ -134,7 +134,7 @@ const galleryId = `event-gallery-${heading
           View all {images.length} photographs
         </strong>
         <span class="text-muted-foreground mt-1 block text-sm">
-          Portraits, workshop coverage, and downloadable event photographs
+          Browse the complete gallery and download individual photographs
         </span>
       </span>
       <ChevronDown

--- a/src/content/portfolio/arqam-academy.mdx
+++ b/src/content/portfolio/arqam-academy.mdx
@@ -1,5 +1,5 @@
 ---
-order: 10
+order: 11
 title: Arqam Academy
 seoDescription: Professional staff headshots and portrait photography for Arqam Academy, creating a consistent and approachable visual identity for its team.
 status: complete

--- a/src/content/portfolio/aya-academy.mdx
+++ b/src/content/portfolio/aya-academy.mdx
@@ -1,5 +1,5 @@
 ---
-order: 8
+order: 9
 title: Aya Academy
 seoTitle: Aya Academy Graduation Video | Ayoub Abedrabbo
 seoDescription: Full graduation ceremony videography and video production for American Youth Academy in Tampa, preserving the complete senior celebration for families.

--- a/src/content/portfolio/bayaan-academy.mdx
+++ b/src/content/portfolio/bayaan-academy.mdx
@@ -1,5 +1,5 @@
 ---
-order: 7
+order: 8
 title: Bayaan Academy
 seoDescription: Multi-year staff portraits, student yearbook photography, graduation coverage, and event photography produced for Bayaan Academy in the Tampa area.
 status: complete

--- a/src/content/portfolio/konan-bbq-podcast.mdx
+++ b/src/content/portfolio/konan-bbq-podcast.mdx
@@ -1,5 +1,5 @@
 ---
-order: 6
+order: 7
 title: Konan BBQ Podcast
 status: complete
 category: Podcast production

--- a/src/content/portfolio/lavena-health.mdx
+++ b/src/content/portfolio/lavena-health.mdx
@@ -1,5 +1,5 @@
 ---
-order: 5
+order: 6
 title: Lavena Wellness
 status: complete
 category: Podcast & social media

--- a/src/content/portfolio/maan-academy.mdx
+++ b/src/content/portfolio/maan-academy.mdx
@@ -1,5 +1,5 @@
 ---
-order: 9
+order: 10
 title: "Ma'an Academy"
 seoDescription: Brand videography and production for Ma'an Academy, creating a public-facing showcase film that introduces the school, its identity, and its community.
 status: complete

--- a/src/content/portfolio/muslim-business-chamber-2026.mdx
+++ b/src/content/portfolio/muslim-business-chamber-2026.mdx
@@ -1,5 +1,5 @@
 ---
-order: 0
+order: 1
 title: 'Muslim Chamber of Commerce USA: AI for Small Business'
 seoTitle: Muslim Chamber of Commerce USA Event Photography | Tampa
 seoDescription: Event photography, attendee portraits, lecture recording, and video coverage for the Muslim Chamber of Commerce USA workshop on using AI to grow a small business in Tampa.

--- a/src/content/portfolio/omar-erchid-law-firm.mdx
+++ b/src/content/portfolio/omar-erchid-law-firm.mdx
@@ -1,5 +1,5 @@
 ---
-order: 4
+order: 5
 title: Erchid Law Firm & Titletown Closing
 status: complete
 category: Video production

--- a/src/content/portfolio/portraits.mdx
+++ b/src/content/portfolio/portraits.mdx
@@ -1,5 +1,5 @@
 ---
-order: 2
+order: 3
 title: Portraits
 seoTitle: Tampa Portrait Photography | Ayoub Abedrabbo
 seoDescription: Professional headshots and environmental portrait photography in Tampa for medical professionals, community leaders, teams, and everyday people.

--- a/src/content/portfolio/rizqmd-jd-podcast.mdx
+++ b/src/content/portfolio/rizqmd-jd-podcast.mdx
@@ -1,5 +1,5 @@
 ---
-order: 3
+order: 4
 title: RizqMD JD Podcast
 seoDescription: Full podcast video production for RizqMD JD, including a consistent multi-camera setup, lighting, clean audio, editing, and YouTube-ready delivery.
 status: complete

--- a/src/content/portfolio/sanad-silwadi-wedding.mdx
+++ b/src/content/portfolio/sanad-silwadi-wedding.mdx
@@ -1,0 +1,51 @@
+---
+order: 0
+title: Sanad Silwadi — Wedding Celebration
+seoTitle: Sanad Silwadi Wedding Photography | Ayoub Abedrabbo
+seoDescription: A documentary wedding gallery photographed for Sanad Silwadi on Saturday, June 20, 2026.
+status: complete
+category: Wedding photography
+summary: A warm outdoor wedding gathering for Sanad Silwadi, photographed through candid portraits, greetings, and the people who came to celebrate.
+thumbnail:
+  src: https://photos.ayoubabed.xyz/events/sanad-silwadi-06-20-2026/images/P1301034.jpg
+  width: 2400
+  height: 1600
+  alt: Guest portrait at Sanad Silwadi's wedding celebration
+  filename: P1301034.jpg
+  featured: true
+heroImage:
+  src: https://photos.ayoubabed.xyz/events/sanad-silwadi-06-20-2026/images/P1301034.jpg
+  width: 2400
+  height: 1600
+  alt: Guest portrait at Sanad Silwadi's wedding celebration
+  filename: P1301034.jpg
+  featured: true
+imageAlt: Guest portrait at Sanad Silwadi's wedding celebration
+imageWidth: 2400
+imageHeight: 1600
+services:
+  - Wedding photography
+  - Candid event coverage
+  - Guest portraits
+role: Wedding photographer
+duration: Saturday, June 20, 2026
+outcomes:
+  - 201 edited photographs delivered in a private event gallery
+  - High-resolution collection available as a single download
+galleryHeading: Sanad's wedding photographs
+galleryDescription: A documentary record of the evening—from quiet portraits to greetings, laughter, and the people gathered around Sanad. Select any photograph to view it larger or download a copy.
+galleryLayout: masonry
+eventGallery: true
+downloadAllUrl: https://photos.ayoubabed.xyz/events/sanad-silwadi-06-20-2026/downloads/sanad-silwadi-06-20-2026.zip
+gallery: []
+---
+
+## An evening with Sanad
+
+On Saturday, June 20, 2026, I photographed Sanad Silwadi's wedding gathering as friends and family arrived, greeted one another, and settled into the evening together.
+
+The photographs move between composed portraits and the small, unscripted moments that give a celebration its character: an embrace at arrival, friends pulling together for a photograph, conversations under the trees, and the shift from daylight into the warm lights of the night.
+
+## The approach
+
+I kept the coverage relaxed and people-first, making room for guests to be themselves while still creating a complete visual record for Sanad. The finished collection includes 201 edited photographs, available to browse individually or download together from the gallery below.

--- a/src/content/portfolio/ya-hala.mdx
+++ b/src/content/portfolio/ya-hala.mdx
@@ -1,5 +1,5 @@
 ﻿---
-order: 1
+order: 2
 title: Ya Hala with Haithum
 status: complete
 category: Web and field production

--- a/src/data/event-galleries.ts
+++ b/src/data/event-galleries.ts
@@ -1,0 +1,82 @@
+export type RemoteEventGalleryImage = {
+  src: string
+  width: number
+  height: number
+  alt: string
+  filename: string
+  featured: boolean
+}
+
+type PhotoSpec = {
+  filename: string
+  width: number
+  height: number
+}
+
+const photoRange = (
+  prefix: string,
+  start: number,
+  end: number,
+  width: number,
+  height: number,
+): PhotoSpec[] =>
+  Array.from({ length: end - start + 1 }, (_, index) => {
+    const number = start + index
+
+    return {
+      filename: `${prefix}${number}.jpg`,
+      width,
+      height,
+    }
+  })
+
+const sanadFeatured = new Set([
+  'P1301034.jpg',
+  'P1301041.jpg',
+  'P1301055.jpg',
+  'P1301064.jpg',
+  'P1301095.jpg',
+  'P1301112.jpg',
+  'P1301158.jpg',
+  'P1301180.jpg',
+  'P1301195.jpg',
+  'P1301202.jpg',
+  'P1301225.jpg',
+  'P1301272.jpg',
+])
+
+const sanadPhotoSpecs = [
+  ...photoRange('P130', 1034, 1036, 2400, 1600),
+  ...photoRange('P130', 1037, 1040, 1600, 2400),
+  ...photoRange('P130', 1041, 1042, 2400, 1600),
+  ...photoRange('P130', 1043, 1050, 1600, 2400),
+  ...photoRange('P130', 1051, 1052, 2400, 1600),
+  ...photoRange('P130', 1053, 1054, 1600, 2400),
+  ...photoRange('P130', 1055, 1066, 2400, 1600),
+  ...photoRange('P130', 1067, 1084, 1600, 2400),
+  ...photoRange('P130', 1085, 1087, 2400, 1600),
+  ...photoRange('P130', 1088, 1093, 1600, 2400),
+  ...photoRange('P130', 1094, 1096, 2400, 1600),
+  ...photoRange('P130', 1097, 1111, 1600, 2400),
+  ...photoRange('P130', 1112, 1116, 2400, 1600),
+  ...photoRange('P130', 1117, 1153, 1600, 2400),
+  ...photoRange('P130', 1154, 1158, 2400, 1600),
+  ...photoRange('P130', 1159, 1179, 1600, 2400),
+  ...photoRange('P130', 1180, 1188, 2400, 1600),
+  ...photoRange('P130', 1190, 1202, 2400, 1600),
+  ...photoRange('P130', 1203, 1205, 1600, 2400),
+  ...photoRange('P130', 1206, 1211, 2400, 1600),
+  ...photoRange('P130', 1212, 1223, 1600, 2400),
+  ...photoRange('P130', 1224, 1228, 2400, 1600),
+  ...photoRange('P130', 1271, 1273, 2400, 1600),
+  ...photoRange('P131', 1315, 1318, 2400, 1600),
+]
+
+export const eventGalleries: Record<string, RemoteEventGalleryImage[]> = {
+  'sanad-silwadi-wedding': sanadPhotoSpecs.map((photo, index) => ({
+    ...photo,
+    src: `https://photos.ayoubabed.xyz/events/sanad-silwadi-06-20-2026/images/${photo.filename}`,
+    alt: `Sanad Silwadi wedding celebration photograph ${index + 1}`,
+    featured: sanadFeatured.has(photo.filename),
+  })),
+}

--- a/src/pages/portfolio/[slug].astro
+++ b/src/pages/portfolio/[slug].astro
@@ -19,6 +19,7 @@ import {
 } from '../../components/ui/breadcrumb'
 import { buttonVariants } from '../../components/ui/button'
 import { Separator } from '../../components/ui/separator'
+import { eventGalleries } from '../../data/event-galleries'
 import { cn } from '../../lib/utils'
 
 export async function getStaticPaths() {
@@ -65,14 +66,16 @@ const heroImage =
     ? heroImageAsset.src
     : (heroImageAsset as ImageMetadata | string)
 const remoteGalleryImages = projectData.eventGallery
-  ? projectData.gallery.filter(
-      (
-        image,
-      ): image is Extract<
-        (typeof projectData.gallery)[number],
-        { filename: string }
-      > => 'filename' in image,
-    )
+  ? projectData.gallery.length > 0
+    ? projectData.gallery.filter(
+        (
+          image,
+        ): image is Extract<
+          (typeof projectData.gallery)[number],
+          { filename: string }
+        > => 'filename' in image,
+      )
+    : (eventGalleries[project.id] ?? [])
   : []
 const galleryImages = projectData.eventGallery
   ? []


### PR DESCRIPTION
## Summary
- Add a new Sanad Silwadi wedding portfolio page with metadata, narrative copy, and gallery download links
- Introduce a remote event gallery data source so the page can render 201 hosted photographs
- Update portfolio ordering and gallery helper copy to reflect the new event-focused flow

## Testing
- Not run (not requested)