### PR TITLE
Fix calendar dropdown caption on mobile

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -63,12 +63,25 @@ function Calendar({
           defaultClassNames.button_next,
         ),
         month_caption: cn(
-          'flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)',
+          'flex min-h-(--cell-size) w-full items-center justify-center px-(--cell-size)',
           defaultClassNames.month_caption,
         ),
         caption_label: cn(
           'text-sm font-medium',
           defaultClassNames.caption_label,
+        ),
+        dropdowns: cn(
+          'flex min-w-0 flex-wrap items-center justify-center gap-x-1 gap-y-0.5',
+          defaultClassNames.dropdowns,
+        ),
+        dropdown_root: cn('relative min-w-0', defaultClassNames.dropdown_root),
+        dropdown: cn(
+          'bg-background text-foreground h-8 max-w-24 rounded-md border border-transparent px-2 text-sm font-medium outline-none',
+          defaultClassNames.dropdown,
+        ),
+        chevron: cn(
+          'text-muted-foreground pointer-events-none absolute top-1/2 right-1 size-3 -translate-y-1/2',
+          defaultClassNames.chevron,
         ),
         month_grid: cn('w-full border-collapse', defaultClassNames.month_grid),
         weekdays: cn('flex', defaultClassNames.weekdays),


### PR DESCRIPTION
Contains the shadcn calendar month/year dropdown caption on small screens.