### PR TITLE
Let gallery name wrap in admin

### DIFF
--- a/src/components/AdminGallery.tsx
+++ b/src/components/AdminGallery.tsx
@@ -630,8 +630,9 @@ export default function AdminGallery({
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="event-title">Name</Label>
-                <Input
+                <Textarea
                   id="event-title"
+                  rows={2}
                   value={meta.title}
                   onChange={(event) =>
                     setMeta((current) => ({


### PR DESCRIPTION
Changes the edit-gallery name field from a single-line input to a two-row textarea so long event names are visible on mobile.