### PR TITLE
Fix Lavena portfolio map

### DIFF
--- a/src/components/PortfolioLocation.astro
+++ b/src/components/PortfolioLocation.astro
@@ -16,7 +16,8 @@ const { title, address, latitude, longitude, plusCode, googleMapsUrl } =
 
 const [streetAddress, ...localityParts] = address.split(', ')
 const locality = localityParts.join(', ')
-const mapContainerId = `map-container-${Math.random().toString(36).slice(2, 9)}`
+const bboxOffset = 0.012
+const mapSrc = `https://www.openstreetmap.org/export/embed.html?bbox=${longitude - bboxOffset}%2C${latitude - bboxOffset}%2C${longitude + bboxOffset}%2C${latitude + bboxOffset}&layer=mapnik&marker=${latitude}%2C${longitude}`
 ---
 
 <section
@@ -27,85 +28,13 @@ const mapContainerId = `map-container-${Math.random().toString(36).slice(2, 9)}`
     class="bg-muted/35 ring-border/70 grid overflow-hidden ring-1 md:grid-cols-[minmax(0,1.2fr)_minmax(20rem,0.8fr)]"
   >
     <div class="bg-muted relative min-h-72 overflow-hidden md:min-h-80">
-      <link
-        rel="stylesheet"
-        href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
-        crossorigin=""
-      />
-      <div
-        id={mapContainerId}
-        class="size-full contrast-[.92] saturate-[.55] transition-[filter] duration-300 hover:saturate-75 focus:saturate-75 dark:brightness-[.8] dark:contrast-[1.05]"
+      <iframe
+        title={`Map showing ${title}`}
+        src={mapSrc}
+        loading="lazy"
+        class="size-full border-0 contrast-[.92] saturate-[.55] transition-[filter] duration-300 hover:saturate-75 focus:saturate-75 dark:brightness-[.8] dark:contrast-[1.05]"
       >
-      </div>
-      <script
-        is:inline
-        src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-        crossorigin=""
-      >
-      </script>
-      <script
-        is:inline
-        define:vars={{ mapContainerId, latitude, longitude, googleMapsUrl }}
-      >
-        ;(() => {
-          const container = document.getElementById(mapContainerId)
-          if (!container || typeof L === 'undefined') return
-
-          const map = L.map(container, {
-            center: [latitude, longitude],
-            zoom: 13,
-            zoomControl: false,
-            attributionControl: false,
-            scrollWheelZoom: false,
-            dragging: false,
-            doubleClickZoom: false,
-            boxZoom: false,
-            keyboard: false,
-          })
-
-          L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            maxZoom: 19,
-          }).addTo(map)
-
-          const customIcon = L.divIcon({
-            className: 'custom-pin-icon',
-            html: `<div style="
-              width: 32px;
-              height: 32px;
-              background: #2563eb;
-              border: 3px solid white;
-              border-radius: 50% 50% 50% 0;
-              transform: rotate(-45deg);
-              box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-              cursor: pointer;
-            ">
-              <div style="
-                width: 10px;
-                height: 10px;
-                background: white;
-                border-radius: 50%;
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
-              "></div>
-            </div>`,
-            iconSize: [32, 32],
-            iconAnchor: [16, 32],
-          })
-
-          const marker = L.marker([latitude, longitude], {
-            icon: customIcon,
-            interactive: true,
-          }).addTo(map)
-
-          marker.on('click', () => {
-            window.open(googleMapsUrl, '_blank', 'noopener,noreferrer')
-          })
-        })()
-      </script>
+      </iframe>
     </div>
 
     <div


### PR DESCRIPTION
## Summary
- Replace the blocked Leaflet/unpkg map setup with an OpenStreetMap embed allowed by the existing CSP.
- Keep the existing location details and Google Maps outbound link.

## Verification
- npm run verify
- Local Lavena page contains the OpenStreetMap iframe and no Leaflet/unpkg references.