### PR TITLE
Deepen event gallery resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gallery:manifest": "node scripts/generate-event-gallery-manifest.mjs",
     "gallery:prune": "node scripts/prune-gallery.mjs",
     "test:gallery-prune": "node --test scripts/gallery-prune-core.test.mjs",
-    "test:galleries": "tsx --test src/lib/gallery-auth.test.ts src/lib/gallery-upload.test.ts src/lib/gallery-admin.test.ts",
+    "test:galleries": "tsx --test src/lib/gallery-auth.test.ts src/lib/gallery-upload.test.ts src/lib/gallery-admin.test.ts src/lib/gallery-read.test.ts",
     "faces:index": "node scripts/face-index.mjs",
     "faces:publish": "node scripts/face-publish.mjs",
     "faces:delete": "node scripts/face-delete.mjs",

--- a/src/lib/gallery-read.test.ts
+++ b/src/lib/gallery-read.test.ts
@@ -77,12 +77,11 @@ function reader(
       listInvites: async () => [],
       getInvite: async () => invite,
     },
-    fallbackImages: {},
   })
 }
 
 test('D1 controls visibility and overrides mutable gallery metadata', async () => {
-  const gallery = await reader().get('event-one')
+  const gallery = await reader().getPublicDetail('event-one')
 
   assert.equal(gallery?.title, 'Dynamic title')
   assert.equal(gallery?.summary, 'Dynamic summary')
@@ -92,7 +91,9 @@ test('D1 controls visibility and overrides mutable gallery metadata', async () =
 })
 
 test('static-only event galleries remain publicly readable', async () => {
-  const gallery = await reader({ dynamicValue: undefined }).get('event-one')
+  const gallery = await reader({
+    dynamicValue: undefined,
+  }).getPublicDetail('event-one')
 
   assert.equal(gallery?.title, 'Static title')
   assert.equal(gallery?.summary, 'Static gallery description')
@@ -113,9 +114,9 @@ test('hidden galleries are absent from public reads but available to admin reads
   const hidden = { ...dynamicEvent, status: 'hidden' as const }
   const galleryReader = reader({ dynamicValue: hidden })
 
-  assert.equal(await galleryReader.get('event-one'), undefined)
+  assert.equal(await galleryReader.getPublicDetail('event-one'), undefined)
   assert.equal(
-    (await galleryReader.getAdmin('event-one'))?.visibility,
+    (await galleryReader.getAdminDetail('event-one'))?.visibility,
     'hidden',
   )
 })

--- a/src/lib/gallery-read.test.ts
+++ b/src/lib/gallery-read.test.ts
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { CollectionEntry } from 'astro:content'
+
+import { createGalleryReader } from './gallery-read'
+import type { EventGallery, GalleryPhoto, GuestPhoto } from './gallery-data'
+
+const staticEvent = {
+  id: 'event-one',
+  data: {
+    eventGallery: true,
+    title: 'Static title',
+    summary: 'Static summary',
+    galleryDescription: 'Static gallery description',
+    category: 'Static category',
+    featuredImage: '/static-cover.jpg',
+    imageAlt: 'Static cover',
+    gallery: [],
+  },
+} as unknown as CollectionEntry<'portfolio'>
+
+const dynamicEvent: EventGallery = {
+  event_slug: 'event-one',
+  title: 'Dynamic title',
+  event_date: '2026-07-09',
+  event_time: null,
+  event_venue: null,
+  summary: 'Dynamic summary',
+  category: 'Dynamic category',
+  flyer_object_key: null,
+  flyer_width: null,
+  flyer_height: null,
+  flyer_alt: null,
+  cover_src: null,
+  cover_width: null,
+  cover_height: null,
+  cover_alt: null,
+  coming_soon: 0,
+  status: 'published',
+  created_at: 1,
+  updated_at: 1,
+}
+
+function reader(
+  options: {
+    staticValue?: typeof staticEvent | undefined
+    dynamicValue?: typeof dynamicEvent | undefined
+    invite?: {
+      token: string
+      event_slug: string
+      guest_name: string
+      created_at: number
+      last_used_at: number | null
+    } | null
+    photos?: GalleryPhoto[]
+    publishedGuests?: GuestPhoto[]
+  } = {},
+) {
+  const staticValue =
+    'staticValue' in options ? options.staticValue : staticEvent
+  const dynamicValue =
+    'dynamicValue' in options ? options.dynamicValue : dynamicEvent
+  const invite = options.invite ?? null
+  return createGalleryReader({
+    staticContent: {
+      get: async () => staticValue,
+      list: async () => (staticValue ? [staticValue] : []),
+    },
+    records: {
+      getEvent: async () => dynamicValue,
+      listEvents: async () => (dynamicValue ? [dynamicValue] : []),
+      getSettings: async () => null,
+      getHiddenFilenames: async () => new Set(),
+      listPublishedGuests: async () => options.publishedGuests ?? [],
+      listGuests: async () => [],
+      listPhotos: async () => options.photos ?? [],
+      listInvites: async () => [],
+      getInvite: async () => invite,
+    },
+    fallbackImages: {},
+  })
+}
+
+test('D1 controls visibility and overrides mutable gallery metadata', async () => {
+  const gallery = await reader().get('event-one')
+
+  assert.equal(gallery?.title, 'Dynamic title')
+  assert.equal(gallery?.summary, 'Dynamic summary')
+  assert.equal(gallery?.category, 'Dynamic category')
+  assert.equal(gallery?.visibility, 'published')
+  assert.equal(gallery?.staticEvent, staticEvent)
+})
+
+test('static-only event galleries remain publicly readable', async () => {
+  const gallery = await reader({ dynamicValue: undefined }).get('event-one')
+
+  assert.equal(gallery?.title, 'Static title')
+  assert.equal(gallery?.summary, 'Static gallery description')
+  assert.equal(gallery?.visibility, 'published')
+})
+
+test('D1-only galleries expose a public detail model for every route', async () => {
+  const gallery = await reader({ staticValue: undefined }).getPublicDetail(
+    'event-one',
+  )
+
+  assert.equal(gallery?.eventSlug, 'event-one')
+  assert.equal(gallery?.title, 'Dynamic title')
+  assert.deepEqual(gallery?.allImages, [])
+})
+
+test('hidden galleries are absent from public reads but available to admin reads', async () => {
+  const hidden = { ...dynamicEvent, status: 'hidden' as const }
+  const galleryReader = reader({ dynamicValue: hidden })
+
+  assert.equal(await galleryReader.get('event-one'), undefined)
+  assert.equal(
+    (await galleryReader.getAdmin('event-one'))?.visibility,
+    'hidden',
+  )
+})
+
+test('invite context only resolves for the requested event', async () => {
+  const invite = {
+    token: 'invite-token',
+    event_slug: 'event-one',
+    guest_name: 'Ayoub',
+    created_at: 1,
+    last_used_at: null,
+  }
+  const galleryReader = reader({ invite })
+
+  assert.equal(
+    (await galleryReader.getInviteContext('event-one', 'invite-token'))?.invite,
+    invite,
+  )
+  assert.equal(
+    await galleryReader.getInviteContext('another-event', 'invite-token'),
+    undefined,
+  )
+})
+
+test('public detail projects related rows and suppresses photos while coming soon', async () => {
+  const photo: GalleryPhoto = {
+    id: 'admin-photo',
+    event_slug: 'event-one',
+    object_key: 'events/event-one/photos/admin-photo.jpg',
+    original_filename: 'photo.jpg',
+    width: 1200,
+    height: 800,
+    alt: 'Admin photo',
+    uploader_name: null,
+    source: 'admin',
+    created_at: 1,
+  }
+  const guest: GuestPhoto = {
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'events/event-one/guest/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1200,
+    height: 800,
+    alt: 'Guest photo',
+    status: 'published',
+    created_at: 1,
+    published_at: 1,
+  }
+
+  const published = await reader({
+    photos: [photo],
+    publishedGuests: [guest],
+  }).getPublicDetail('event-one')
+  assert.deepEqual(
+    published?.allImages.map((image) => ('id' in image ? image.id : undefined)),
+    ['admin-photo', 'guest-photo'],
+  )
+
+  const comingSoon = await reader({
+    dynamicValue: { ...dynamicEvent, status: 'coming_soon', coming_soon: 1 },
+    photos: [photo],
+    publishedGuests: [guest],
+  }).getPublicDetail('event-one')
+  assert.deepEqual(comingSoon?.allImages, [])
+})

--- a/src/lib/gallery-read.ts
+++ b/src/lib/gallery-read.ts
@@ -44,7 +44,6 @@ type GalleryRecordAdapter = {
 type GalleryReaderDependencies = {
   staticContent: StaticContentAdapter
   records: GalleryRecordAdapter
-  fallbackImages: typeof eventGalleries
 }
 
 function validStaticEvent(event: StaticEvent | undefined) {
@@ -77,7 +76,6 @@ function metadata(
 export function createGalleryReader({
   staticContent,
   records,
-  fallbackImages,
 }: GalleryReaderDependencies) {
   async function resolve(eventSlug: string, includeHidden: boolean) {
     const [staticRow, dynamicEvent] = await Promise.all([
@@ -114,11 +112,13 @@ export function createGalleryReader({
     dynamicEvents: EventGallery[],
   ) {
     return [
-      ...staticEvents
-        .filter(({ data }) => data.eventGallery)
-        .map(({ id }) => id),
-      ...dynamicEvents.map(({ event_slug }) => event_slug),
-    ].filter((slug, index, all) => all.indexOf(slug) === index)
+      ...new Set([
+        ...staticEvents
+          .filter(({ data }) => data.eventGallery)
+          .map(({ id }) => id),
+        ...dynamicEvents.map(({ event_slug }) => event_slug),
+      ]),
+    ]
   }
 
   function staticProfessionalImages(
@@ -132,7 +132,7 @@ export function createGalleryReader({
       : []
     return inlineImages.length > 0
       ? inlineImages
-      : (fallbackImages[gallery.eventSlug] ?? [])
+      : (eventGalleries[gallery.eventSlug] ?? [])
   }
 
   async function publicDetail(eventSlug: string) {
@@ -323,9 +323,6 @@ export function createGalleryReader({
     get(eventSlug: string) {
       return resolve(eventSlug, false)
     },
-    getAdmin(eventSlug: string) {
-      return resolve(eventSlug, true)
-    },
     getPublicDetail: publicDetail,
     getAdminDetail: adminDetail,
     listPublic,
@@ -377,6 +374,5 @@ export function galleryReader(database: D1Database) {
       },
     },
     records: databaseRecords(database),
-    fallbackImages: eventGalleries,
   })
 }

--- a/src/lib/gallery-read.ts
+++ b/src/lib/gallery-read.ts
@@ -1,0 +1,382 @@
+import type { CollectionEntry } from 'astro:content'
+
+import { eventGalleries } from '../data/event-galleries'
+import {
+  getEventGallery,
+  getGalleryInvite,
+  getGallerySettings,
+  getHiddenFilenames,
+  listEventGalleries,
+  listGalleryInvites,
+  listGalleryPhotos,
+  listGuestPhotos,
+  listPublishedGuestPhotos,
+  publicEventCover,
+  publicEventFlyer,
+  publicGalleryPhoto,
+  publicGuestPhoto,
+  type EventGallery,
+  type GalleryInvite,
+  type GalleryPhoto,
+  type GallerySettings,
+  type GuestPhoto,
+} from './gallery-data'
+
+type StaticEvent = CollectionEntry<'portfolio'>
+
+type StaticContentAdapter = {
+  get(eventSlug: string): Promise<StaticEvent | undefined>
+  list(): Promise<StaticEvent[]>
+}
+
+type GalleryRecordAdapter = {
+  getEvent(eventSlug: string): Promise<EventGallery | undefined>
+  listEvents(): Promise<EventGallery[]>
+  getSettings(eventSlug: string): Promise<GallerySettings | null>
+  getHiddenFilenames(eventSlug: string): Promise<Set<string>>
+  listPublishedGuests(eventSlug: string): Promise<GuestPhoto[]>
+  listGuests(eventSlug: string): Promise<GuestPhoto[]>
+  listPhotos(eventSlug: string): Promise<GalleryPhoto[]>
+  listInvites(eventSlug: string): Promise<GalleryInvite[]>
+  getInvite(token: string): Promise<GalleryInvite | null>
+}
+
+type GalleryReaderDependencies = {
+  staticContent: StaticContentAdapter
+  records: GalleryRecordAdapter
+  fallbackImages: typeof eventGalleries
+}
+
+function validStaticEvent(event: StaticEvent | undefined) {
+  return event?.data.eventGallery ? event : undefined
+}
+
+function metadata(
+  staticEvent: StaticEvent | undefined,
+  dynamicEvent: EventGallery | undefined,
+) {
+  return {
+    title: dynamicEvent?.title ?? staticEvent?.data.title ?? 'Event gallery',
+    summary:
+      dynamicEvent?.summary ??
+      staticEvent?.data.galleryDescription ??
+      staticEvent?.data.summary ??
+      '',
+    category:
+      dynamicEvent?.category ??
+      staticEvent?.data.category ??
+      'Event Photography',
+    eventDate: dynamicEvent?.event_date
+      ? new Date(`${dynamicEvent.event_date}T00:00:00Z`)
+      : staticEvent?.data.eventDate,
+    eventTime: dynamicEvent?.event_time ?? staticEvent?.data.eventTime,
+    eventVenue: dynamicEvent?.event_venue ?? staticEvent?.data.eventVenue,
+  }
+}
+
+export function createGalleryReader({
+  staticContent,
+  records,
+  fallbackImages,
+}: GalleryReaderDependencies) {
+  async function resolve(eventSlug: string, includeHidden: boolean) {
+    const [staticRow, dynamicEvent] = await Promise.all([
+      staticContent.get(eventSlug),
+      records.getEvent(eventSlug),
+    ])
+    const staticEvent = validStaticEvent(staticRow)
+    if (!staticEvent && !dynamicEvent) return
+    if (!includeHidden && dynamicEvent?.status === 'hidden') return
+
+    return {
+      eventSlug,
+      staticEvent,
+      dynamicEvent,
+      visibility: dynamicEvent?.status ?? ('published' as const),
+      comingSoon:
+        dynamicEvent?.status === 'coming_soon' ||
+        Boolean(dynamicEvent?.coming_soon),
+      ...metadata(staticEvent, dynamicEvent),
+      flyer: dynamicEvent ? publicEventFlyer(dynamicEvent) : undefined,
+      cover: dynamicEvent ? publicEventCover(dynamicEvent) : undefined,
+      featuredImage: staticEvent?.data.featuredImage,
+      featuredImageSrc: staticEvent
+        ? typeof staticEvent.data.featuredImage === 'string'
+          ? staticEvent.data.featuredImage
+          : staticEvent.data.featuredImage.src
+        : undefined,
+      imageAlt: staticEvent?.data.imageAlt,
+    }
+  }
+
+  function gallerySlugs(
+    staticEvents: StaticEvent[],
+    dynamicEvents: EventGallery[],
+  ) {
+    return [
+      ...staticEvents
+        .filter(({ data }) => data.eventGallery)
+        .map(({ id }) => id),
+      ...dynamicEvents.map(({ event_slug }) => event_slug),
+    ].filter((slug, index, all) => all.indexOf(slug) === index)
+  }
+
+  function staticProfessionalImages(
+    gallery: NonNullable<Awaited<ReturnType<typeof resolve>>>,
+  ) {
+    const inlineImages = gallery.staticEvent
+      ? gallery.staticEvent.data.gallery.filter(
+          (image): image is Extract<typeof image, { filename: string }> =>
+            'filename' in image,
+        )
+      : []
+    return inlineImages.length > 0
+      ? inlineImages
+      : (fallbackImages[gallery.eventSlug] ?? [])
+  }
+
+  async function publicDetail(eventSlug: string) {
+    const gallery = await resolve(eventSlug, false)
+    if (!gallery) return
+    const [settings, hiddenFilenames, publishedGuests, uploadedPhotos] =
+      await Promise.all([
+        records.getSettings(eventSlug),
+        records.getHiddenFilenames(eventSlug),
+        records.listPublishedGuests(eventSlug),
+        records.listPhotos(eventSlug),
+      ])
+    const staticImages = staticProfessionalImages(gallery)
+    const uploadedImages = gallery.comingSoon
+      ? []
+      : uploadedPhotos.map(publicGalleryPhoto)
+    const professionalImages = [
+      ...staticImages.filter((image) => !hiddenFilenames.has(image.filename)),
+      ...uploadedImages.filter((image) => image.source === 'admin'),
+    ]
+    const guestImages = gallery.comingSoon
+      ? []
+      : [
+          ...publishedGuests.map(publicGuestPhoto),
+          ...uploadedImages.filter((image) => image.source === 'guest'),
+        ]
+    const staticFlyer =
+      typeof gallery.featuredImage === 'object' &&
+      gallery.featuredImage !== null &&
+      !('filename' in gallery.featuredImage)
+        ? gallery.featuredImage
+        : undefined
+    const remoteFeaturedImage =
+      typeof gallery.featuredImage === 'object' &&
+      gallery.featuredImage !== null &&
+      'filename' in gallery.featuredImage &&
+      !hiddenFilenames.has(gallery.featuredImage.filename)
+        ? gallery.featuredImage
+        : undefined
+    const allImages = [...professionalImages, ...guestImages]
+
+    return {
+      ...gallery,
+      settings,
+      hiddenFilenames,
+      professionalImages,
+      guestImages,
+      allImages,
+      ogImage:
+        gallery.cover?.src ??
+        allImages[0]?.src ??
+        gallery.flyer?.src ??
+        gallery.featuredImageSrc ??
+        '/og.jpg',
+      flyerImage: staticFlyer ?? gallery.flyer,
+      heroImage: gallery.cover ?? remoteFeaturedImage ?? professionalImages[0],
+    }
+  }
+
+  async function adminDetail(eventSlug: string) {
+    const gallery = await resolve(eventSlug, true)
+    if (!gallery) return
+    const [settings, guests, hiddenFilenames, uploadedPhotos, invites] =
+      await Promise.all([
+        records.getSettings(eventSlug),
+        records.listGuests(eventSlug),
+        records.getHiddenFilenames(eventSlug),
+        records.listPhotos(eventSlug),
+        records.listInvites(eventSlug),
+      ])
+    const professionalImages = staticProfessionalImages(gallery)
+
+    return {
+      ...gallery,
+      settings,
+      guests,
+      uploadedPhotos,
+      invites,
+      professional: professionalImages.map((image) => ({
+        src: image.src,
+        alt: image.alt,
+        filename: image.filename,
+        width: image.width,
+        height: image.height,
+        hidden: hiddenFilenames.has(image.filename),
+      })),
+    }
+  }
+
+  async function listPublic() {
+    const [staticEvents, dynamicEvents] = await Promise.all([
+      staticContent.list(),
+      records.listEvents(),
+    ])
+    const slugs = gallerySlugs(staticEvents, dynamicEvents)
+    const galleries = await Promise.all(
+      slugs.map(async (eventSlug) => {
+        const detail = await publicDetail(eventSlug)
+        if (!detail) return
+        const staticEvent = detail.staticEvent
+        const requestedCover =
+          detail.cover ??
+          staticEvent?.data.thumbnail ??
+          staticEvent?.data.featuredImage ??
+          detail.flyer
+        const requestedCoverIsHidden =
+          typeof requestedCover === 'object' &&
+          requestedCover !== null &&
+          'filename' in requestedCover &&
+          detail.hiddenFilenames.has(requestedCover.filename)
+        const coverAsset = requestedCoverIsHidden
+          ? detail.allImages[0]
+          : (requestedCover ?? detail.allImages[0])
+        const isRemote =
+          typeof coverAsset === 'object' &&
+          coverAsset !== null &&
+          'filename' in coverAsset
+        return {
+          id: eventSlug,
+          title: detail.title,
+          category: detail.category,
+          eventDate: detail.eventDate,
+          photoCount: detail.comingSoon ? 0 : detail.allImages.length,
+          isRemote,
+          cover: isRemote ? (coverAsset as { src: string }).src : coverAsset,
+          coverAlt: isRemote
+            ? (coverAsset as { alt: string }).alt
+            : coverAsset
+              ? (staticEvent?.data.imageAlt ?? `${detail.title} gallery`)
+              : 'No published photographs',
+          coverWidth: isRemote
+            ? (coverAsset as { width: number }).width
+            : (staticEvent?.data.imageWidth ?? 1200),
+          coverHeight: isRemote
+            ? (coverAsset as { height: number }).height
+            : (staticEvent?.data.imageHeight ?? 800),
+        }
+      }),
+    )
+    return galleries
+      .filter((gallery) => gallery)
+      .sort((a, b) => {
+        const aTime = a.eventDate?.getTime() ?? 0
+        const bTime = b.eventDate?.getTime() ?? 0
+        return bTime - aTime
+      })
+  }
+
+  async function listAdmin() {
+    const [staticEvents, dynamicEvents] = await Promise.all([
+      staticContent.list(),
+      records.listEvents(),
+    ])
+    const slugs = gallerySlugs(staticEvents, dynamicEvents)
+    return Promise.all(
+      slugs.map(async (eventSlug) => {
+        const [gallery, settings, guests, photos] = await Promise.all([
+          resolve(eventSlug, true),
+          records.getSettings(eventSlug),
+          records.listGuests(eventSlug),
+          records.listPhotos(eventSlug),
+        ])
+        if (!gallery) throw new Error(`Gallery disappeared: ${eventSlug}`)
+        const cover =
+          gallery.staticEvent?.data.thumbnail ??
+          gallery.staticEvent?.data.featuredImage ??
+          gallery.flyer
+        return {
+          event: gallery.staticEvent ?? { id: eventSlug },
+          settings,
+          pending: guests.filter(({ status }) => status === 'pending').length,
+          published:
+            guests.filter(({ status }) => status === 'published').length +
+            (gallery.staticEvent ? 0 : photos.length),
+          cover,
+          coverAlt:
+            gallery.staticEvent?.data.imageAlt ?? `${gallery.title} flyer`,
+          category: gallery.category,
+          title: gallery.title,
+          eventDate: gallery.eventDate,
+          visibilityStatus: gallery.visibility,
+        }
+      }),
+    )
+  }
+
+  return {
+    get(eventSlug: string) {
+      return resolve(eventSlug, false)
+    },
+    getAdmin(eventSlug: string) {
+      return resolve(eventSlug, true)
+    },
+    getPublicDetail: publicDetail,
+    getAdminDetail: adminDetail,
+    listPublic,
+    listAdmin,
+    async getUploadContext(eventSlug: string) {
+      const [gallery, settings] = await Promise.all([
+        resolve(eventSlug, false),
+        records.getSettings(eventSlug),
+      ])
+      if (!gallery) return
+      return { gallery, settings }
+    },
+    async getInviteContext(eventSlug: string, token: string) {
+      const [gallery, invite] = await Promise.all([
+        resolve(eventSlug, false),
+        records.getInvite(token),
+      ])
+      if (!gallery || invite?.event_slug !== eventSlug) return
+      return { gallery, invite }
+    },
+  }
+}
+
+function databaseRecords(database: D1Database): GalleryRecordAdapter {
+  return {
+    getEvent: (eventSlug) => getEventGallery(database, eventSlug),
+    listEvents: () => listEventGalleries(database),
+    getSettings: (eventSlug) => getGallerySettings(database, eventSlug),
+    getHiddenFilenames: (eventSlug) => getHiddenFilenames(database, eventSlug),
+    listPublishedGuests: (eventSlug) =>
+      listPublishedGuestPhotos(database, eventSlug),
+    listGuests: (eventSlug) => listGuestPhotos(database, eventSlug),
+    listPhotos: (eventSlug) => listGalleryPhotos(database, eventSlug),
+    listInvites: (eventSlug) => listGalleryInvites(database, eventSlug),
+    getInvite: (token) => getGalleryInvite(database, token),
+  }
+}
+
+export function galleryReader(database: D1Database) {
+  return createGalleryReader({
+    staticContent: {
+      async get(eventSlug) {
+        const { getEntry } = await import('astro:content')
+        return getEntry('portfolio', eventSlug)
+      },
+      async list() {
+        const { getCollection } = await import('astro:content')
+        return getCollection('portfolio')
+      },
+    },
+    records: databaseRecords(database),
+    fallbackImages: eventGalleries,
+  })
+}

--- a/src/pages/admin/galleries/[slug].astro
+++ b/src/pages/admin/galleries/[slug].astro
@@ -1,24 +1,13 @@
 ---
 import '../../../styles.css'
 
-import { getEntry } from 'astro:content'
 import { env } from 'cloudflare:workers'
 import { ArrowLeft, ExternalLink } from 'lucide-react'
 
 import AdminGallery from '../../../components/AdminGallery'
 import { Button } from '../../../components/ui/button'
-import { eventGalleries } from '../../../data/event-galleries'
 import { galleryAdminAuthorized } from '../../../lib/gallery-admin'
-import {
-  getEventGallery,
-  getGallerySettings,
-  getHiddenFilenames,
-  listGalleryInvites,
-  listGalleryPhotos,
-  listGuestPhotos,
-  publicEventCover,
-  publicEventFlyer,
-} from '../../../lib/gallery-data'
+import { galleryReader } from '../../../lib/gallery-read'
 import BaseLayout from '../../../layouts/BaseLayout.astro'
 
 export const prerender = false
@@ -35,71 +24,32 @@ if (
 }
 
 const eventSlug = Astro.params.slug
-const staticEvent = eventSlug
-  ? await getEntry('portfolio', eventSlug)
+const gallery = eventSlug
+  ? await galleryReader(env.GALLERY_DB).getAdminDetail(eventSlug)
   : undefined
-const event = staticEvent?.data.eventGallery ? staticEvent : undefined
-const dynamicEvent = eventSlug
-  ? await getEventGallery(env.GALLERY_DB, eventSlug)
-  : undefined
-if ((!event && !dynamicEvent) || !eventSlug) {
+if (!gallery || !eventSlug) {
   return new Response(null, { status: 404 })
 }
-
-const [settings, guests, hiddenFilenames, uploadedPhotos, invites] =
-  await Promise.all([
-    getGallerySettings(env.GALLERY_DB, eventSlug),
-    listGuestPhotos(env.GALLERY_DB, eventSlug),
-    getHiddenFilenames(env.GALLERY_DB, eventSlug),
-    listGalleryPhotos(env.GALLERY_DB, eventSlug),
-    listGalleryInvites(env.GALLERY_DB, eventSlug),
-  ])
-const inlineImages = event
-  ? event.data.gallery.filter(
-      (
-        image,
-      ): image is Extract<
-        (typeof event.data.gallery)[number],
-        { filename: string }
-      > => 'filename' in image,
-    )
-  : []
-const professionalImages =
-  inlineImages.length > 0 ? inlineImages : (eventGalleries[eventSlug] ?? [])
-const professional = professionalImages.map((image) => ({
-  src: image.src,
-  alt: image.alt,
-  filename: image.filename,
-  width: image.width,
-  height: image.height,
-  hidden: hiddenFilenames.has(image.filename),
-}))
+const event = gallery.staticEvent
+const { settings, guests, uploadedPhotos, invites, professional } = gallery
 const ogImage =
-  (dynamicEvent ? publicEventFlyer(dynamicEvent)?.src : undefined) ??
+  gallery.flyer?.src ??
   (event
     ? typeof event.data.featuredImage === 'string'
       ? event.data.featuredImage
       : event.data.featuredImage.src
     : '/og.jpg')
-const eventTitle = dynamicEvent?.title ?? event?.data.title ?? 'Event gallery'
+const eventTitle = gallery.title
 const eventMeta = {
   title: eventTitle,
-  summary:
-    dynamicEvent?.summary ??
-    event?.data.galleryDescription ??
-    event?.data.summary ??
-    '',
-  category:
-    dynamicEvent?.category ?? event?.data.category ?? 'Event Photography',
-  eventDate:
-    dynamicEvent?.event_date ??
-    event?.data.eventDate?.toISOString().slice(0, 10) ??
-    '',
-  eventTime: dynamicEvent?.event_time ?? event?.data.eventTime ?? '',
-  eventVenue: dynamicEvent?.event_venue ?? event?.data.eventVenue ?? '',
-  comingSoon: dynamicEvent ? Boolean(dynamicEvent.coming_soon) : false,
-  visibilityStatus: dynamicEvent?.status ?? 'published',
-  coverSrc: dynamicEvent ? publicEventCover(dynamicEvent)?.src : undefined,
+  summary: gallery.summary,
+  category: gallery.category,
+  eventDate: gallery.eventDate?.toISOString().slice(0, 10) ?? '',
+  eventTime: gallery.eventTime ?? '',
+  eventVenue: gallery.eventVenue ?? '',
+  comingSoon: gallery.comingSoon,
+  visibilityStatus: gallery.visibility,
+  coverSrc: gallery.cover?.src,
 }
 
 Astro.response.headers.set('X-Robots-Tag', 'noindex, nofollow')

--- a/src/pages/admin/galleries/index.astro
+++ b/src/pages/admin/galleries/index.astro
@@ -3,7 +3,6 @@ import '../../../styles.css'
 
 import type { ImageMetadata } from 'astro'
 import { Image } from 'astro:assets'
-import { getCollection } from 'astro:content'
 import { env } from 'cloudflare:workers'
 import { ChevronRight, Images } from 'lucide-react'
 
@@ -16,14 +15,7 @@ import {
   CardTitle,
 } from '../../../components/ui/card'
 import { galleryAdminAuthorized } from '../../../lib/gallery-admin'
-import {
-  getEventGallery,
-  getGallerySettings,
-  listEventGalleries,
-  listGalleryPhotos,
-  listGuestPhotos,
-  publicEventFlyer,
-} from '../../../lib/gallery-data'
+import { galleryReader } from '../../../lib/gallery-read'
 import BaseLayout from '../../../layouts/BaseLayout.astro'
 
 export const prerender = false
@@ -39,60 +31,7 @@ if (
   return new Response('Forbidden', { status: 403 })
 }
 
-const events = (await getCollection('portfolio')).filter(
-  ({ data }) => data.eventGallery,
-)
-const staticGalleries = await Promise.all(
-  events.map(async (event) => {
-    const [settings, guests, dynamicEvent] = await Promise.all([
-      getGallerySettings(env.GALLERY_DB, event.id),
-      listGuestPhotos(env.GALLERY_DB, event.id),
-      getEventGallery(env.GALLERY_DB, event.id),
-    ])
-    const cover = event.data.thumbnail ?? event.data.featuredImage
-    return {
-      event,
-      settings,
-      pending: guests.filter(({ status }) => status === 'pending').length,
-      published: guests.filter(({ status }) => status === 'published').length,
-      cover,
-      coverAlt: event.data.imageAlt,
-      category: event.data.category,
-      title: event.data.title,
-      eventDate: event.data.eventDate,
-      visibilityStatus: dynamicEvent?.status ?? 'published',
-    }
-  }),
-)
-const dynamicEvents = await listEventGalleries(env.GALLERY_DB)
-const dynamicGalleries = await Promise.all(
-  dynamicEvents
-    .filter((event) => !events.some((entry) => entry.id === event.event_slug))
-    .map(async (event) => {
-      const [settings, guests, photos] = await Promise.all([
-        getGallerySettings(env.GALLERY_DB, event.event_slug),
-        listGuestPhotos(env.GALLERY_DB, event.event_slug),
-        listGalleryPhotos(env.GALLERY_DB, event.event_slug),
-      ])
-      return {
-        event: { id: event.event_slug },
-        settings,
-        pending: guests.filter(({ status }) => status === 'pending').length,
-        published:
-          guests.filter(({ status }) => status === 'published').length +
-          photos.length,
-        cover: publicEventFlyer(event),
-        coverAlt: `${event.title} flyer`,
-        category: event.category,
-        title: event.title,
-        eventDate: event.event_date
-          ? new Date(`${event.event_date}T00:00:00Z`)
-          : undefined,
-        visibilityStatus: event.status,
-      }
-    }),
-)
-const galleries = [...staticGalleries, ...dynamicGalleries]
+const galleries = await galleryReader(env.GALLERY_DB).listAdmin()
 const firstCover = galleries[0]?.cover
 const ogImage =
   typeof firstCover === 'string'

--- a/src/pages/api/galleries/[slug]/session.ts
+++ b/src/pages/api/galleries/[slug]/session.ts
@@ -1,5 +1,4 @@
 import type { APIRoute } from 'astro'
-import { getEntry } from 'astro:content'
 import { env } from 'cloudflare:workers'
 
 import {
@@ -8,7 +7,7 @@ import {
   validGalleryPassword,
   verifyGalleryPassword,
 } from '@/lib/gallery-auth'
-import { getEventGallery, getGallerySettings } from '@/lib/gallery-data'
+import { galleryReader } from '@/lib/gallery-read'
 
 export const prerender = false
 
@@ -25,12 +24,10 @@ export const POST: APIRoute = async ({ params, request }) => {
   const eventSlug = params.slug
   if (!eventSlug) return json({ error: 'Gallery not found.' }, 404)
 
-  const event = await getEntry('portfolio', eventSlug)
-  if (!event?.data.eventGallery) {
-    return json({ error: 'Gallery not found.' }, 404)
-  }
-  const statusOverride = await getEventGallery(env.GALLERY_DB, eventSlug)
-  if (statusOverride?.status === 'hidden') {
+  const context = await galleryReader(env.GALLERY_DB).getUploadContext(
+    eventSlug,
+  )
+  if (!context) {
     return json({ error: 'Gallery not found.' }, 404)
   }
 
@@ -66,7 +63,7 @@ export const POST: APIRoute = async ({ params, request }) => {
     return json({ error: 'Invalid password.' }, 401)
   }
 
-  const settings = await getGallerySettings(env.GALLERY_DB, eventSlug)
+  const { settings } = context
   if (
     !settings?.uploads_enabled ||
     !settings.password_salt ||

--- a/src/pages/api/galleries/[slug]/uploads.ts
+++ b/src/pages/api/galleries/[slug]/uploads.ts
@@ -1,18 +1,15 @@
 import type { APIRoute } from 'astro'
-import { getEntry } from 'astro:content'
 import { env } from 'cloudflare:workers'
 
 import { gallerySessionCookie, verifyGallerySession } from '@/lib/gallery-auth'
 import {
   adminPhotoKey,
-  getEventGallery,
-  getGalleryInvite,
-  getGallerySettings,
   insertGalleryPhoto,
   insertPendingGuestPhoto,
   markGalleryInviteUsed,
   pendingGuestKey,
 } from '@/lib/gallery-data'
+import { galleryReader } from '@/lib/gallery-read'
 import {
   acceptedGalleryImage,
   MAX_GALLERY_UPLOAD_BYTES,
@@ -32,29 +29,24 @@ export const POST: APIRoute = async ({ params, request }) => {
   const eventSlug = params.slug
   if (!eventSlug) return json({ error: 'Gallery not found.' }, 404)
 
-  const staticEvent = await getEntry('portfolio', eventSlug)
-  const dynamicEvent = staticEvent?.data.eventGallery
-    ? undefined
-    : await getEventGallery(env.GALLERY_DB, eventSlug)
-  if (!staticEvent?.data.eventGallery && !dynamicEvent) {
+  const reader = galleryReader(env.GALLERY_DB)
+  const gallery = await reader.get(eventSlug)
+  if (!gallery) {
     return json({ error: 'Gallery not found.' }, 404)
   }
-  if (dynamicEvent?.status === 'hidden') {
-    return json({ error: 'Gallery not found.' }, 404)
-  }
-  const eventTitle =
-    staticEvent?.data.title ?? dynamicEvent?.title ?? 'the event'
+  const eventTitle = gallery.title
   const inviteToken = new URL(request.url).searchParams.get('invite')?.trim()
-  const invite = inviteToken
-    ? await getGalleryInvite(env.GALLERY_DB, inviteToken)
-    : null
-  if (inviteToken && invite?.event_slug !== eventSlug) {
+  const inviteContext = inviteToken
+    ? await reader.getInviteContext(eventSlug, inviteToken)
+    : undefined
+  const invite = inviteContext?.invite
+  if (inviteToken && !invite) {
     return json({ error: 'This upload link is not valid.' }, 403)
   }
 
   const sessionToken = gallerySessionCookie(request)
   if (!invite) {
-    const settings = await getGallerySettings(env.GALLERY_DB, eventSlug)
+    const settings = (await reader.getUploadContext(eventSlug))?.settings
     if (!settings?.uploads_enabled) {
       return json({ error: 'Uploads are not open for this gallery.' }, 403)
     }

--- a/src/pages/galleries.astro
+++ b/src/pages/galleries.astro
@@ -1,9 +1,7 @@
 ---
 import '../styles.css'
 
-import type { ImageMetadata } from 'astro'
 import { Image } from 'astro:assets'
-import { getCollection } from 'astro:content'
 import { env } from 'cloudflare:workers'
 import { Calendar, Images } from 'lucide-react'
 
@@ -15,18 +13,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '../components/ui/empty'
-import { eventGalleries } from '../data/event-galleries'
-import {
-  getEventGallery,
-  getHiddenFilenames,
-  listPublicEventGalleries,
-  listGalleryPhotos,
-  listPublishedGuestPhotos,
-  publicEventCover,
-  publicEventFlyer,
-  publicGalleryPhoto,
-  publicGuestPhoto,
-} from '../lib/gallery-data'
+import { galleryReader } from '../lib/gallery-read'
 import BaseLayout from '../layouts/BaseLayout.astro'
 
 export const prerender = false
@@ -41,121 +28,7 @@ const formatDate = (date: Date) =>
     timeZone: 'UTC',
   }).format(date)
 
-const collections = await getCollection('portfolio')
-const staticGalleries = await Promise.all(
-  collections
-    .filter((entry) => entry.data.eventGallery)
-    .map(async (entry) => {
-      const [hiddenFilenames, guestPhotos, uploadedPhotos, statusOverride] =
-        await Promise.all([
-          getHiddenFilenames(env.GALLERY_DB, entry.id),
-          listPublishedGuestPhotos(env.GALLERY_DB, entry.id),
-          listGalleryPhotos(env.GALLERY_DB, entry.id),
-          getEventGallery(env.GALLERY_DB, entry.id),
-        ])
-      if (statusOverride?.status === 'hidden') return
-      const inlineRemoteImages = entry.data.gallery.filter(
-        (image) => 'filename' in image,
-      )
-      const professionalImages =
-        inlineRemoteImages.length > 0
-          ? inlineRemoteImages
-          : (eventGalleries[entry.id] ?? [])
-      const visibleProfessional = professionalImages.filter(
-        (image) => !hiddenFilenames.has(image.filename),
-      )
-      const requestedCover =
-        (statusOverride ? publicEventCover(statusOverride) : undefined) ??
-        entry.data.thumbnail ??
-        entry.data.featuredImage
-      const requestedCoverIsHidden =
-        typeof requestedCover === 'object' &&
-        requestedCover !== null &&
-        'filename' in requestedCover &&
-        hiddenFilenames.has(requestedCover.filename)
-      const coverAsset = requestedCoverIsHidden
-        ? (visibleProfessional[0] ??
-          (uploadedPhotos[0]
-            ? publicGalleryPhoto(uploadedPhotos[0])
-            : undefined) ??
-          (guestPhotos[0] ? publicGuestPhoto(guestPhotos[0]) : undefined))
-        : requestedCover
-      const isRemote =
-        typeof coverAsset === 'object' &&
-        coverAsset !== null &&
-        'filename' in coverAsset
-      const comingSoon = statusOverride?.status === 'coming_soon'
-      const photoCount = comingSoon
-        ? 0
-        : visibleProfessional.length +
-          guestPhotos.length +
-          uploadedPhotos.length
-      return {
-        id: entry.id,
-        title: statusOverride?.title ?? entry.data.title,
-        category: statusOverride?.category ?? entry.data.category,
-        eventDate: statusOverride?.event_date
-          ? new Date(`${statusOverride.event_date}T00:00:00Z`)
-          : entry.data.eventDate,
-        photoCount,
-        isRemote,
-        cover: isRemote
-          ? (coverAsset as { src: string }).src
-          : (coverAsset as ImageMetadata | undefined),
-        coverAlt: isRemote
-          ? (coverAsset as { alt: string }).alt
-          : coverAsset
-            ? entry.data.imageAlt
-            : 'No published photographs',
-        coverWidth: isRemote
-          ? (coverAsset as { width: number }).width
-          : entry.data.imageWidth,
-        coverHeight: isRemote
-          ? (coverAsset as { height: number }).height
-          : entry.data.imageHeight,
-      }
-    }),
-)
-const dynamicEvents = await listPublicEventGalleries(env.GALLERY_DB)
-const dynamicGalleries = await Promise.all(
-  dynamicEvents
-    .filter(
-      (event) => !collections.some((entry) => entry.id === event.event_slug),
-    )
-    .map(async (event) => {
-      const photos = await listGalleryPhotos(env.GALLERY_DB, event.event_slug)
-      const coverAsset =
-        publicEventCover(event) ??
-        publicEventFlyer(event) ??
-        (event.status === 'published' && photos[0]
-          ? publicGalleryPhoto(photos[0])
-          : undefined)
-      const photoCount = event.status === 'coming_soon' ? 0 : photos.length
-      return {
-        id: event.event_slug,
-        title: event.title,
-        category: event.category,
-        eventDate: event.event_date
-          ? new Date(`${event.event_date}T00:00:00Z`)
-          : undefined,
-        photoCount,
-        isRemote: Boolean(coverAsset),
-        cover: coverAsset?.src,
-        coverAlt: coverAsset?.alt ?? `${event.title} flyer`,
-        coverWidth: coverAsset?.width ?? 1200,
-        coverHeight: coverAsset?.height ?? 800,
-      }
-    }),
-)
-const sortedGalleries = [
-  ...staticGalleries.filter((gallery) => gallery),
-  ...dynamicGalleries,
-].sort((a, b) => {
-  const aTime = a.eventDate?.getTime() ?? 0
-  const bTime = b.eventDate?.getTime() ?? 0
-  if (bTime !== aTime) return bTime - aTime
-  return 0
-})
+const sortedGalleries = await galleryReader(env.GALLERY_DB).listPublic()
 
 const title = 'Event Galleries — Ayoub Abedrabbo'
 const description =

--- a/src/pages/galleries/[slug]/index.astro
+++ b/src/pages/galleries/[slug]/index.astro
@@ -3,7 +3,6 @@ import '../../../styles.css'
 
 import { Image } from 'astro:assets'
 import { ArrowRight, Heart, ImageUp } from 'lucide-react'
-import { getEntry } from 'astro:content'
 import { env } from 'cloudflare:workers'
 
 import EventLightbox from '../../../components/EventLightbox'
@@ -19,149 +18,43 @@ import {
 } from '../../../components/ui/breadcrumb'
 import { Badge } from '../../../components/ui/badge'
 import { Button } from '../../../components/ui/button'
-import { eventGalleries } from '../../../data/event-galleries'
 import BaseLayout from '../../../layouts/BaseLayout.astro'
 import { faceManifests } from '../../../lib/face-manifests'
-import {
-  getEventGallery,
-  getGallerySettings,
-  getHiddenFilenames,
-  listGalleryPhotos,
-  listPublishedGuestPhotos,
-  publicEventCover,
-  publicEventFlyer,
-  publicGalleryPhoto,
-  publicGuestPhoto,
-} from '../../../lib/gallery-data'
+import { galleryReader } from '../../../lib/gallery-read'
 import { siteConfig } from '../../../lib/site-config'
 
 export const prerender = false
 
-type RemoteGalleryImage = {
-  src: string
-  width: number
-  height: number
-  alt: string
-  filename: string
-  caption?: string
-  featured?: boolean
-}
-
 const eventSlug = Astro.params.slug
-const staticProject = eventSlug
-  ? await getEntry('portfolio', eventSlug)
+const gallery = eventSlug
+  ? await galleryReader(env.GALLERY_DB).getPublicDetail(eventSlug)
   : undefined
-const project = staticProject?.data.eventGallery ? staticProject : undefined
-const dynamicEvent = eventSlug
-  ? await getEventGallery(env.GALLERY_DB, eventSlug)
-  : undefined
-if ((!project && !dynamicEvent) || !eventSlug) {
+if (!gallery || !eventSlug) {
   return new Response(null, { status: 404 })
 }
-if (dynamicEvent?.status === 'hidden') {
-  return new Response(null, { status: 404 })
-}
+const project = gallery.staticEvent
+const dynamicEvent = gallery.dynamicEvent
 const data = project?.data
-const [hiddenFilenames, publishedGuests, gallerySettings, uploadedPhotos] =
-  await Promise.all([
-    getHiddenFilenames(env.GALLERY_DB, eventSlug),
-    listPublishedGuestPhotos(env.GALLERY_DB, eventSlug),
-    getGallerySettings(env.GALLERY_DB, eventSlug),
-    listGalleryPhotos(env.GALLERY_DB, eventSlug),
-  ])
-
-const inlineImages = data
-  ? data.gallery.filter(
-      (
-        image,
-      ): image is Extract<
-        (typeof data.gallery)[number],
-        { filename: string }
-      > => 'filename' in image,
-    )
-  : []
-const fallbackImages = eventGalleries[eventSlug] ?? []
-const rawImages: RemoteGalleryImage[] =
-  inlineImages.length > 0
-    ? (inlineImages as unknown as RemoteGalleryImage[])
-    : fallbackImages
-
-const dynamicComingSoon =
-  dynamicEvent?.status === 'coming_soon' || Boolean(dynamicEvent?.coming_soon)
-const uploadedImages = dynamicComingSoon
-  ? []
-  : uploadedPhotos.map(publicGalleryPhoto)
-const adminUploadedImages = uploadedImages.filter(
-  (image) => image.source === 'admin',
-)
-const images = [
-  ...rawImages
-    .filter((image) => !hiddenFilenames.has(image.filename))
-    .map((image) => ({
-      src: image.src,
-      width: image.width,
-      height: image.height,
-      alt: image.alt,
-      filename: image.filename,
-      caption: image.caption,
-      featured: image.featured,
-    })),
-  ...adminUploadedImages,
-]
-const guestImages = dynamicComingSoon
-  ? []
-  : [
-      ...publishedGuests.map(publicGuestPhoto),
-      ...uploadedImages.filter((image) => image.source === 'guest'),
-    ]
-const allImages = [...images, ...guestImages]
+const gallerySettings = gallery.settings
+const images = gallery.professionalImages
+const guestImages = gallery.guestImages
+const allImages = gallery.allImages
 const totalPhotoCount = allImages.length
 
 const galleryId = `gallery-${eventSlug}`
 const galleryUrl = new URL(`/galleries/${eventSlug}/`, Astro.site).toString()
 const portfolioUrl = project ? `/portfolio/${project.id}/` : '/galleries/'
-const galleryTitle = dynamicEvent?.title ?? data?.title ?? 'Event Gallery'
-const galleryCategory =
-  dynamicEvent?.category ?? data?.category ?? 'Event Photography'
+const galleryTitle = gallery.title
+const galleryCategory = gallery.category
 const galleryImageAlt = data?.imageAlt ?? `${galleryTitle} event gallery`
-const summary =
-  dynamicEvent?.summary ?? data?.galleryDescription ?? data?.summary ?? ''
+const summary = gallery.summary
 const title = `${galleryTitle} - Event Gallery`
-const ogImage =
-  (dynamicEvent ? publicEventCover(dynamicEvent)?.src : undefined) ??
-  allImages[0]?.src ??
-  (dynamicEvent ? publicEventFlyer(dynamicEvent)?.src : undefined) ??
-  (data
-    ? typeof data.featuredImage === 'string'
-      ? data.featuredImage
-      : data.featuredImage.src
-    : '/og.jpg')
-const eventDate = dynamicEvent?.event_date
-  ? new Date(`${dynamicEvent.event_date}T00:00:00Z`)
-  : data?.eventDate
+const ogImage = gallery.ogImage
+const eventDate = gallery.eventDate
 const tipUrl = siteConfig.socialLinks.find((link) => link.id === 'kofi')?.url
 const faceManifest = faceManifests[eventSlug]
-const flyer =
-  data &&
-  typeof data.featuredImage === 'object' &&
-  data.featuredImage !== null &&
-  !('filename' in data.featuredImage)
-    ? (data.featuredImage as ImageMetadata)
-    : dynamicEvent
-      ? publicEventFlyer(dynamicEvent)
-      : undefined
-const remoteFeaturedImage =
-  data &&
-  typeof data.featuredImage === 'object' &&
-  data.featuredImage !== null &&
-  'filename' in data.featuredImage &&
-  !hiddenFilenames.has(data.featuredImage.filename)
-    ? data.featuredImage
-    : undefined
-const galleryHeroImage =
-  (dynamicEvent ? publicEventCover(dynamicEvent) : undefined) ??
-  remoteFeaturedImage ??
-  images[0]
+const flyer = gallery.flyerImage
+const galleryHeroImage = gallery.heroImage
 
 const formatDate = (date: Date) =>
   new Intl.DateTimeFormat('en-US', {

--- a/src/pages/galleries/[slug]/index.astro
+++ b/src/pages/galleries/[slug]/index.astro
@@ -33,7 +33,6 @@ if (!gallery || !eventSlug) {
   return new Response(null, { status: 404 })
 }
 const project = gallery.staticEvent
-const dynamicEvent = gallery.dynamicEvent
 const data = project?.data
 const gallerySettings = gallery.settings
 const images = gallery.professionalImages
@@ -243,8 +242,8 @@ const formatDate = (date: Date) =>
           flyer={flyer}
           flyerAlt={galleryImageAlt}
           date={eventDate ? formatDate(eventDate) : 'Date coming soon'}
-          time={dynamicEvent?.event_time ?? data?.eventTime ?? undefined}
-          venue={dynamicEvent?.event_venue ?? data?.eventVenue ?? undefined}
+          time={gallery.eventTime ?? undefined}
+          venue={gallery.eventVenue ?? undefined}
           upcomingVideo={data?.upcomingVideo}
         />
       ) : (

--- a/src/pages/galleries/[slug]/photo/[photo].astro
+++ b/src/pages/galleries/[slug]/photo/[photo].astro
@@ -1,14 +1,8 @@
 ---
-import { getEntry } from 'astro:content'
 import { env } from 'cloudflare:workers'
 
 import CloudflareWebAnalytics from '../../../../components/CloudflareWebAnalytics.astro'
-import { eventGalleries } from '../../../../data/event-galleries'
-import {
-  getHiddenFilenames,
-  listPublishedGuestPhotos,
-  publicGuestPhoto,
-} from '../../../../lib/gallery-data'
+import { galleryReader } from '../../../../lib/gallery-read'
 
 export const prerender = false
 
@@ -21,46 +15,30 @@ type ShareImage = {
 
 const eventSlug = Astro.params.slug
 const photoNumber = Number(Astro.params.photo)
-const project = eventSlug ? await getEntry('portfolio', eventSlug) : undefined
+const gallery = eventSlug
+  ? await galleryReader(env.GALLERY_DB).getPublicDetail(eventSlug)
+  : undefined
 if (
-  !project?.data.eventGallery ||
+  !gallery ||
   !eventSlug ||
   !Number.isSafeInteger(photoNumber) ||
   photoNumber < 1
 ) {
   return new Response(null, { status: 404 })
 }
-
-const inlineImages = project.data.gallery.filter(
-  (
-    image,
-  ): image is Extract<
-    (typeof project.data.gallery)[number],
-    { filename: string }
-  > => 'filename' in image,
-)
-const professionalImages =
-  inlineImages.length > 0 ? inlineImages : (eventGalleries[project.id] ?? [])
-const [hiddenFilenames, guestRows] = await Promise.all([
-  getHiddenFilenames(env.GALLERY_DB, eventSlug),
-  listPublishedGuestPhotos(env.GALLERY_DB, eventSlug),
-])
-const images: ShareImage[] = [
-  ...professionalImages.filter((image) => !hiddenFilenames.has(image.filename)),
-  ...guestRows.map(publicGuestPhoto),
-]
+const images: ShareImage[] = gallery.allImages
 const image = images[photoNumber - 1]
 if (!image) return new Response(null, { status: 404 })
 const photoCount = images.length
 
 const shareUrl = new URL(
-  `/galleries/${project.id}/photo/${photoNumber}/`,
+  `/galleries/${gallery.eventSlug}/photo/${photoNumber}/`,
   Astro.site,
 ).toString()
-const destinationPath = `/galleries/${project.id}/?photo=${photoNumber}`
+const destinationPath = `/galleries/${gallery.eventSlug}/?photo=${photoNumber}`
 
-const title = `${project.data.title} | Photograph ${photoNumber} of ${photoCount}`
-const description = `${image.alt}. View this photograph from ${project.data.title}.`
+const title = `${gallery.title} | Photograph ${photoNumber} of ${photoCount}`
+const description = `${image.alt}. View this photograph from ${gallery.title}.`
 ---
 
 <!doctype html>
@@ -99,7 +77,7 @@ const description = `${image.alt}. View this photograph from ${project.data.titl
   <body>
     <main>
       <p>
-        Opening photograph {photoNumber} from {project.data.title}.
+        Opening photograph {photoNumber} from {gallery.title}.
         <a href={destinationPath}>Continue to the photograph</a>
       </p>
     </main>

--- a/src/pages/galleries/[slug]/upload.astro
+++ b/src/pages/galleries/[slug]/upload.astro
@@ -1,40 +1,31 @@
 ---
 import '../../../styles.css'
 
-import { getEntry } from 'astro:content'
 import { env } from 'cloudflare:workers'
 import { ArrowLeft } from 'lucide-react'
 
 import GuestUpload from '../../../components/GuestUpload'
 import { Button } from '../../../components/ui/button'
-import { getEventGallery, getGallerySettings } from '../../../lib/gallery-data'
+import { galleryReader } from '../../../lib/gallery-read'
 import BaseLayout from '../../../layouts/BaseLayout.astro'
 
 export const prerender = false
 
 const eventSlug = Astro.params.slug
-const event = eventSlug ? await getEntry('portfolio', eventSlug) : undefined
-if (!event?.data.eventGallery || !eventSlug) {
+const context = eventSlug
+  ? await galleryReader(env.GALLERY_DB).getUploadContext(eventSlug)
+  : undefined
+if (!context || !eventSlug) {
   return new Response(null, { status: 404 })
 }
-
-const [settings, statusOverride] = await Promise.all([
-  getGallerySettings(env.GALLERY_DB, eventSlug),
-  getEventGallery(env.GALLERY_DB, eventSlug),
-])
-if (statusOverride?.status === 'hidden') {
-  return new Response(null, { status: 404 })
-}
+const { gallery, settings } = context
 const canonicalUrl = new URL(
   `/galleries/${eventSlug}/upload/`,
   Astro.site,
 ).toString()
-const title = `Share photos from ${event.data.title}`
-const description = `Submit guest photos from ${event.data.title} for review and inclusion in the event gallery.`
-const ogImage =
-  typeof event.data.featuredImage === 'string'
-    ? event.data.featuredImage
-    : event.data.featuredImage.src
+const title = `Share photos from ${gallery.title}`
+const description = `Submit guest photos from ${gallery.title} for review and inclusion in the event gallery.`
+const ogImage = gallery.flyer?.src ?? gallery.featuredImageSrc ?? '/og.jpg'
 
 Astro.response.headers.set('X-Robots-Tag', 'noindex, nofollow')
 ---
@@ -44,7 +35,7 @@ Astro.response.headers.set('X-Robots-Tag', 'noindex, nofollow')
   description={description}
   canonicalUrl={canonicalUrl}
   ogImage={ogImage}
-  ogImageAlt={event.data.imageAlt}
+  ogImageAlt={gallery.imageAlt ?? `${gallery.title} gallery`}
   activeNav="galleries"
 >
   <main
@@ -68,7 +59,7 @@ Astro.response.headers.set('X-Robots-Tag', 'noindex, nofollow')
         Share what you captured
       </h1>
       <p class="text-muted-foreground mt-5 max-w-xl text-lg leading-8">
-        Add your photos from {event.data.title}. Every submission is reviewed
+        Add your photos from {gallery.title}. Every submission is reviewed
         before it appears in the public gallery.
       </p>
     </header>
@@ -77,7 +68,7 @@ Astro.response.headers.set('X-Robots-Tag', 'noindex, nofollow')
       <GuestUpload
         client:only="react"
         eventSlug={eventSlug}
-        eventTitle={event.data.title}
+        eventTitle={gallery.title}
         enabled={Boolean(settings?.uploads_enabled)}
       />
     </div>

--- a/src/pages/galleries/[slug]/upload/[token].astro
+++ b/src/pages/galleries/[slug]/upload/[token].astro
@@ -1,17 +1,12 @@
 ---
 import '../../../../styles.css'
 
-import { getEntry } from 'astro:content'
 import { env } from 'cloudflare:workers'
 import { ArrowLeft } from 'lucide-react'
 
 import GuestUpload from '../../../../components/GuestUpload'
 import { Button } from '../../../../components/ui/button'
-import {
-  getEventGallery,
-  getGalleryInvite,
-  publicEventFlyer,
-} from '../../../../lib/gallery-data'
+import { galleryReader } from '../../../../lib/gallery-read'
 import BaseLayout from '../../../../layouts/BaseLayout.astro'
 
 export const prerender = false
@@ -22,36 +17,17 @@ if (!eventSlug || !token) {
   return new Response(null, { status: 404 })
 }
 
-const [staticEvent, dynamicEvent, invite] = await Promise.all([
-  getEntry('portfolio', eventSlug),
-  getEventGallery(env.GALLERY_DB, eventSlug),
-  getGalleryInvite(env.GALLERY_DB, token),
-])
-const validStaticEvent = staticEvent?.data.eventGallery
-  ? staticEvent
-  : undefined
-if ((!validStaticEvent && !dynamicEvent) || invite?.event_slug !== eventSlug) {
+const context = await galleryReader(env.GALLERY_DB).getInviteContext(
+  eventSlug,
+  token,
+)
+if (!context) {
   return new Response(null, { status: 404 })
 }
-if (dynamicEvent?.status === 'hidden') {
-  return new Response(null, { status: 404 })
-}
-
-const eventTitle =
-  validStaticEvent?.data.title ?? dynamicEvent?.title ?? 'Event'
-const summary =
-  validStaticEvent?.data.galleryDescription ??
-  validStaticEvent?.data.summary ??
-  dynamicEvent?.summary ??
-  ''
-const flyer = dynamicEvent ? publicEventFlyer(dynamicEvent) : undefined
-const ogImage =
-  flyer?.src ??
-  (validStaticEvent
-    ? typeof validStaticEvent.data.featuredImage === 'string'
-      ? validStaticEvent.data.featuredImage
-      : validStaticEvent.data.featuredImage.src
-    : '/og.jpg')
+const { gallery, invite } = context
+const eventTitle = gallery.title
+const summary = gallery.summary
+const ogImage = gallery.flyer?.src ?? gallery.featuredImageSrc ?? '/og.jpg'
 
 Astro.response.headers.set('X-Robots-Tag', 'noindex, nofollow')
 ---


### PR DESCRIPTION
## Summary

- centralize static-content and D1 gallery resolution in a deep read model
- move visibility, metadata, related-row, invite, and public projection rules out of nine page and route callers
- add read-model coverage for precedence, visibility, D1-only galleries, invites, and photo projection
- remove reviewed dead flexibility and duplicated caller-side source logic

## Why

Gallery callers independently reconstructed source precedence and visibility through the storage-shaped `gallery-data` API. Keeping those rules in one read module makes static and D1 galleries behave consistently and prevents hidden or D1-only galleries from diverging by route.

## Impact

Public, upload, API, and admin gallery routes now consume purpose-built read models. Storage write operations remain unchanged.

## Validation

- `npm run verify`
- 15 gallery tests passing
- Astro check: 0 errors
- production build passing
