### PR TITLE
Centralize gallery administration commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gallery:manifest": "node scripts/generate-event-gallery-manifest.mjs",
     "gallery:prune": "node scripts/prune-gallery.mjs",
     "test:gallery-prune": "node --test scripts/gallery-prune-core.test.mjs",
-    "test:galleries": "tsx --test src/lib/gallery-auth.test.ts src/lib/gallery-upload.test.ts src/lib/gallery-admin.test.ts src/lib/gallery-read.test.ts",
+    "test:galleries": "tsx --test src/lib/gallery-auth.test.ts src/lib/gallery-upload.test.ts src/lib/gallery-admin.test.ts src/lib/gallery-read.test.ts src/lib/gallery-admin-commands.test.ts",
     "faces:index": "node scripts/face-index.mjs",
     "faces:publish": "node scripts/face-publish.mjs",
     "faces:delete": "node scripts/face-delete.mjs",

--- a/src/lib/gallery-admin-commands.test.ts
+++ b/src/lib/gallery-admin-commands.test.ts
@@ -16,6 +16,24 @@ import type {
   SaveEventGalleryInput,
 } from './gallery-data'
 
+const bytes = () => new Uint8Array([1, 2, 3])
+
+function guestPhoto(overrides: Partial<GuestPhoto> = {}): GuestPhoto {
+  return {
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'pending/event-one/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'pending',
+    created_at: 1,
+    published_at: null,
+    ...overrides,
+  }
+}
+
 function commandContext(
   event: Partial<GalleryAdminEventContext> = {},
 ): GalleryAdminCommandContext {
@@ -37,32 +55,34 @@ function commandContext(
   }
 }
 
-function createCommandHarness(
-  photo: GuestPhoto,
+type HarnessErrors = {
+  publish?: Error
+  deleteGuest?: Error
+  deletePending?: Error
+  deletePublic?: Error
+  insertPhoto?: Error
+  saveEvent?: Error
+}
+
+function createHarness(
   options: {
-    publishError?: Error
-    deleteGuestError?: Error
-    deletePendingError?: Error
-    deletePublicError?: Error
-    insertPhotoError?: Error
-    saveEventError?: Error
+    photo?: GuestPhoto
     settings?: GallerySettings
     optimized?: { buffer: Uint8Array; width: number; height: number }
+    errors?: HarnessErrors
   } = {},
 ) {
+  const errors = options.errors ?? {}
+  let photo = options.photo ?? guestPhoto()
   const pending = new Map<string, Uint8Array>(
-    photo.status === 'pending'
-      ? [[photo.object_key, new Uint8Array([1, 2, 3])]]
-      : [],
+    photo.status === 'pending' ? [[photo.object_key, bytes()]] : [],
   )
   const published = new Map<string, Uint8Array>(
-    photo.status === 'published'
-      ? [[photo.object_key, new Uint8Array([1, 2, 3])]]
-      : [],
+    photo.status === 'published' ? [[photo.object_key, bytes()]] : [],
   )
-  let storedPhoto = photo
-  let deleted = false
   const hidden = new Set<string>()
+  const logs: Array<Record<string, unknown>> = []
+  let deleted = false
   let savedSettings:
     | { uploadsEnabled: boolean; password?: { salt: string; hash: string } }
     | undefined
@@ -70,20 +90,19 @@ function createCommandHarness(
   let savedInvite:
     Pick<GalleryInvite, 'token' | 'event_slug' | 'guest_name'> | undefined
   let insertedPhoto: Omit<GalleryPhoto, 'created_at'> | undefined
-  const logs: Array<Record<string, unknown>> = []
 
   const dependencies: GalleryAdminCommandDependencies = {
     data: {
       getSettings: async () => options.settings,
-      saveSettings: async (_eventSlug, uploadsEnabled, password) => {
+      saveSettings: async (_slug, uploadsEnabled, password) => {
         savedSettings = { uploadsEnabled, password }
       },
-      getGuestPhoto: async () => storedPhoto,
-      publishGuestPhoto: async (photoId, objectKey, alt) => {
-        if (options.publishError) throw options.publishError
-        storedPhoto = {
-          ...storedPhoto,
-          id: photoId,
+      getGuestPhoto: async () => photo,
+      publishGuestPhoto: async (id, objectKey, alt) => {
+        if (errors.publish) throw errors.publish
+        photo = {
+          ...photo,
+          id,
           object_key: objectKey,
           alt,
           status: 'published',
@@ -91,26 +110,26 @@ function createCommandHarness(
         }
       },
       deleteGuestPhoto: async () => {
-        if (options.deleteGuestError) throw options.deleteGuestError
+        if (errors.deleteGuest) throw errors.deleteGuest
         deleted = true
       },
-      hideProfessionalPhoto: async (_eventSlug, filename) => {
+      hideProfessionalPhoto: async (_slug, filename) => {
         hidden.add(filename)
       },
-      restoreProfessionalPhoto: async (_eventSlug, filename) => {
+      restoreProfessionalPhoto: async (_slug, filename) => {
         hidden.delete(filename)
       },
       listGalleryPhotos: async () => [],
-      listGuestPhotos: async () => [storedPhoto],
+      listGuestPhotos: async () => [photo],
       saveEventGallery: async (input) => {
-        if (options.saveEventError) throw options.saveEventError
+        if (errors.saveEvent) throw errors.saveEvent
         savedEvent = input
       },
       createInvite: async (invite) => {
         savedInvite = invite
       },
       insertGalleryPhoto: async (inserted) => {
-        if (options.insertPhotoError) throw options.insertPhotoError
+        if (errors.insertPhoto) throw errors.insertPhoto
         insertedPhoto = inserted
       },
     },
@@ -125,23 +144,19 @@ function createCommandHarness(
       },
       publicExists: async (key) => published.has(key),
       putPublic: async (key, body) => {
-        if (!(body instanceof Uint8Array)) {
-          throw new Error('The test adapter expected a byte array.')
-        }
+        assert.ok(body instanceof Uint8Array)
         published.set(key, body)
       },
       deletePending: async (key) => {
-        if (options.deletePendingError) throw options.deletePendingError
+        if (errors.deletePending) throw errors.deletePending
         pending.delete(key)
       },
       putPending: async (key, body) => {
-        if (!(body instanceof Uint8Array)) {
-          throw new Error('The test adapter expected a byte array.')
-        }
+        assert.ok(body instanceof Uint8Array)
         pending.set(key, body)
       },
       deletePublic: async (key) => {
-        if (options.deletePublicError) throw options.deletePublicError
+        if (errors.deletePublic) throw errors.deletePublic
         published.delete(key)
       },
     },
@@ -161,266 +176,188 @@ function createCommandHarness(
 
   return {
     dependencies,
+    errors,
     pending,
     published,
-    photo: () => storedPhoto,
+    hidden,
+    logs,
+    photo: () => photo,
     deleted: () => deleted,
     savedSettings: () => savedSettings,
-    hidden,
     savedEvent: () => savedEvent,
     savedInvite: () => savedInvite,
     insertedPhoto: () => insertedPhoto,
-    logs,
   }
 }
 
-test('approving a guest photo publishes it and removes the pending copy', async () => {
-  const original: GuestPhoto = {
-    id: 'guest-photo',
-    event_slug: 'event-one',
-    object_key: 'pending/event-one/guest-photo.jpg',
-    original_filename: 'guest.jpg',
-    width: 1600,
-    height: 900,
-    alt: 'Guest upload',
-    status: 'pending',
-    created_at: 1,
-    published_at: null,
-  }
-  const state = createCommandHarness(original)
+const run = (
+  command: unknown,
+  state: ReturnType<typeof createHarness>,
+  context = commandContext(),
+) => executeGalleryAdminCommand(context, command, state.dependencies)
 
-  const result = await executeGalleryAdminCommand(
-    {
-      event: {
-        id: 'event-one',
-        title: 'Event One',
-        summary: 'Event gallery',
-        category: 'Event Photography',
-        eventDate: null,
-        eventTime: null,
-        eventVenue: null,
-        comingSoon: false,
-        status: 'published',
-        staticPhotos: [],
-      },
-      requestUrl: 'https://example.com/admin/galleries/event-one',
-    },
-    { action: 'approveGuest', photoId: 'guest-photo', alt: 'Approved' },
-    state.dependencies,
+test('approves a guest photo and removes its pending copy', async () => {
+  const state = createHarness()
+  assert.deepEqual(
+    await run(
+      { action: 'approveGuest', photoId: 'guest-photo', alt: 'Approved' },
+      state,
+    ),
+    { status: 200, body: { ok: true } },
   )
-
-  assert.deepEqual(result, { status: 200, body: { ok: true } })
   assert.equal(state.pending.size, 0)
   assert.deepEqual(
-    [...state.published.keys()],
-    ['events/event-one/guest/guest-photo.jpg'],
+    [...state.published],
+    [['events/event-one/guest/guest-photo.jpg', bytes()]],
   )
-  assert.equal(state.photo().status, 'published')
   assert.equal(state.photo().alt, 'Approved')
 })
 
-test('approval removes a copied public image when the database update fails', async () => {
-  const original: GuestPhoto = {
-    id: 'guest-photo',
-    event_slug: 'event-one',
-    object_key: 'pending/event-one/guest-photo.jpg',
-    original_filename: 'guest.jpg',
-    width: 1600,
-    height: 900,
-    alt: 'Guest upload',
-    status: 'pending',
-    created_at: 1,
-    published_at: null,
-  }
+test('rolls back a copied image when guest publishing fails', async () => {
   const failure = new Error('Database unavailable')
-  const state = createCommandHarness(original, { publishError: failure })
-
+  const state = createHarness({ errors: { publish: failure } })
   await assert.rejects(
-    executeGalleryAdminCommand(
-      {
-        event: {
-          id: 'event-one',
-          title: 'Event One',
-          summary: 'Event gallery',
-          category: 'Event Photography',
-          eventDate: null,
-          eventTime: null,
-          eventVenue: null,
-          comingSoon: false,
-          status: 'published',
-          staticPhotos: [],
-        },
-        requestUrl: 'https://example.com/admin/galleries/event-one',
-      },
-      { action: 'approveGuest', photoId: 'guest-photo' },
-      state.dependencies,
-    ),
+    run({ action: 'approveGuest', photoId: 'guest-photo' }, state),
     failure,
   )
-
-  assert.equal(state.published.size, 0)
   assert.equal(state.pending.size, 1)
-  assert.equal(state.photo().status, 'pending')
+  assert.equal(state.published.size, 0)
 })
 
-test('rejecting a pending guest photo removes its image and record', async () => {
-  const original: GuestPhoto = {
-    id: 'guest-photo',
-    event_slug: 'event-one',
-    object_key: 'pending/event-one/guest-photo.jpg',
-    original_filename: 'guest.jpg',
-    width: 1600,
-    height: 900,
-    alt: 'Guest upload',
-    status: 'pending',
-    created_at: 1,
-    published_at: null,
-  }
-  const state = createCommandHarness(original)
-
-  const result = await executeGalleryAdminCommand(
-    {
-      event: {
-        id: 'event-one',
-        title: 'Event One',
-        summary: 'Event gallery',
-        category: 'Event Photography',
-        eventDate: null,
-        eventTime: null,
-        eventVenue: null,
-        comingSoon: false,
-        status: 'published',
-        staticPhotos: [],
-      },
-      requestUrl: 'https://example.com/admin/galleries/event-one',
-    },
-    { action: 'rejectGuest', photoId: 'guest-photo' },
-    state.dependencies,
+test('retries deterministic cleanup after approval succeeds', async () => {
+  const state = createHarness({
+    errors: { deletePending: new Error('Bucket unavailable') },
+  })
+  assert.deepEqual(
+    await run({ action: 'approveGuest', photoId: 'guest-photo' }, state),
+    { status: 200, body: { ok: true } },
+  )
+  assert.equal(state.pending.size, 1)
+  assert.equal(
+    state.logs.some(
+      ({ objectKey }) => objectKey === 'pending/event-one/guest-photo.jpg',
+    ),
+    true,
   )
 
-  assert.deepEqual(result, { status: 200, body: { ok: true } })
+  state.errors.deletePending = undefined
+  await run({ action: 'approveGuest', photoId: 'guest-photo' }, state)
+  assert.equal(state.pending.size, 0)
+})
+
+test('rejects a pending guest photo', async () => {
+  const state = createHarness()
+  await run({ action: 'rejectGuest', photoId: 'guest-photo' }, state)
   assert.equal(state.pending.size, 0)
   assert.equal(state.deleted(), true)
 })
 
-test('uploads cannot be enabled before the gallery has a password', async () => {
-  const state = createCommandHarness({
-    id: 'guest-photo',
-    event_slug: 'event-one',
-    object_key: 'pending/event-one/guest-photo.jpg',
-    original_filename: 'guest.jpg',
-    width: 1600,
-    height: 900,
-    alt: 'Guest upload',
-    status: 'pending',
-    created_at: 1,
-    published_at: null,
-  })
-
+test('restores a pending image when record deletion fails', async () => {
+  const failure = new Error('Database unavailable')
+  const state = createHarness({ errors: { deleteGuest: failure } })
   await assert.rejects(
-    executeGalleryAdminCommand(
-      {
-        event: {
-          id: 'event-one',
-          title: 'Event One',
-          summary: 'Event gallery',
-          category: 'Event Photography',
-          eventDate: null,
-          eventTime: null,
-          eventVenue: null,
-          comingSoon: false,
-          status: 'published',
-          staticPhotos: [],
-        },
-        requestUrl: 'https://example.com/admin/galleries/event-one',
-      },
-      { action: 'settings', uploadsEnabled: true },
-      state.dependencies,
-    ),
+    run({ action: 'rejectGuest', photoId: 'guest-photo' }, state),
+    failure,
+  )
+  assert.equal(state.pending.size, 1)
+})
+
+test('removes a published photo', async () => {
+  const state = createHarness({
+    photo: guestPhoto({
+      status: 'published',
+      object_key: 'events/event-one/guest/guest-photo.jpg',
+      published_at: 2,
+    }),
+  })
+  await run({ action: 'removeGuest', photoId: 'guest-photo' }, state)
+  assert.equal(state.published.size, 0)
+  assert.equal(state.deleted(), true)
+})
+
+test('restores a public image when record deletion fails', async () => {
+  const failure = new Error('Database unavailable')
+  const state = createHarness({
+    photo: guestPhoto({
+      status: 'published',
+      object_key: 'events/event-one/guest/guest-photo.jpg',
+      published_at: 2,
+    }),
+    errors: { deleteGuest: failure },
+  })
+  await assert.rejects(
+    run({ action: 'removeGuest', photoId: 'guest-photo' }, state),
+    failure,
+  )
+  assert.equal(state.published.size, 1)
+})
+
+test('keeps the record when public deletion fails', async () => {
+  const failure = new Error('Bucket unavailable')
+  const state = createHarness({
+    photo: guestPhoto({
+      status: 'published',
+      object_key: 'events/event-one/guest/guest-photo.jpg',
+      published_at: 2,
+    }),
+    errors: { deletePublic: failure },
+  })
+  await assert.rejects(
+    run({ action: 'removeGuest', photoId: 'guest-photo' }, state),
+    failure,
+  )
+  assert.equal(state.deleted(), false)
+  assert.equal(state.published.size, 1)
+})
+
+test('requires a password before enabling uploads', async () => {
+  const state = createHarness()
+  await assert.rejects(
+    run({ action: 'settings', uploadsEnabled: true }, state),
     (error) =>
       error instanceof GalleryAdminCommandError &&
-      error.status === 400 &&
       error.message === 'Set a password before enabling uploads.',
   )
-  assert.equal(state.savedSettings(), undefined)
 })
 
-test('hiding a professional photo validates it against the event gallery', async () => {
-  const state = createCommandHarness({
-    id: 'guest-photo',
-    event_slug: 'event-one',
-    object_key: 'pending/event-one/guest-photo.jpg',
-    original_filename: 'guest.jpg',
-    width: 1600,
-    height: 900,
-    alt: 'Guest upload',
-    status: 'pending',
-    created_at: 1,
-    published_at: null,
-  })
-
-  const result = await executeGalleryAdminCommand(
-    {
-      event: {
-        id: 'event-one',
-        title: 'Event One',
-        summary: 'Event gallery',
-        category: 'Event Photography',
-        eventDate: null,
-        eventTime: null,
-        eventVenue: null,
-        comingSoon: false,
-        status: 'published',
-        staticPhotos: [
-          {
-            src: 'https://photos.example/event-one/pro.jpg',
-            width: 1200,
-            height: 800,
-            alt: 'Professional photo',
-            filename: 'pro.jpg',
-          },
-        ],
-      },
-      requestUrl: 'https://example.com/admin/galleries/event-one',
+test('reuses an existing upload password', async () => {
+  const state = createHarness({
+    settings: {
+      event_slug: 'event-one',
+      uploads_enabled: 0,
+      password_salt: 'salt',
+      password_hash: 'hash',
+      updated_at: 1,
     },
-    { action: 'hideProfessional', filename: 'pro.jpg' },
-    state.dependencies,
+  })
+  await run({ action: 'settings', uploadsEnabled: true }, state)
+  assert.deepEqual(state.savedSettings(), {
+    uploadsEnabled: true,
+    password: undefined,
+  })
+})
+
+test('hides and restores a professional photo', async () => {
+  const state = createHarness()
+  const context = commandContext({
+    staticPhotos: [{ src: 'photo.jpg', filename: 'photo.jpg' }],
+  })
+  await run(
+    { action: 'hideProfessional', filename: 'photo.jpg' },
+    state,
+    context,
   )
-
-  assert.deepEqual(result, { status: 200, body: { ok: true } })
-  assert.deepEqual([...state.hidden], ['pro.jpg'])
+  await run(
+    { action: 'restoreProfessional', filename: 'photo.jpg' },
+    state,
+    context,
+  )
+  assert.deepEqual([...state.hidden], [])
 })
 
-test('updating event details saves one normalized gallery record', async () => {
-  const state = createCommandHarness({
-    id: 'guest-photo',
-    event_slug: 'event-one',
-    object_key: 'pending/event-one/guest-photo.jpg',
-    original_filename: 'guest.jpg',
-    width: 1600,
-    height: 900,
-    alt: 'Guest upload',
-    status: 'pending',
-    created_at: 1,
-    published_at: null,
-  })
-
-  const result = await executeGalleryAdminCommand(
-    {
-      event: {
-        id: 'event-one',
-        title: 'Old title',
-        summary: 'Old summary',
-        category: 'Event Photography',
-        eventDate: null,
-        eventTime: null,
-        eventVenue: null,
-        comingSoon: false,
-        status: 'published',
-        staticPhotos: [],
-      },
-      requestUrl: 'https://example.com/admin/galleries/event-one',
-    },
+test('normalizes updated event details', async () => {
+  const state = createHarness()
+  await run(
     {
       action: 'updateEvent',
       title: '  New title  ',
@@ -432,10 +369,8 @@ test('updating event details saves one normalized gallery record', async () => {
       comingSoon: true,
       visibilityStatus: 'coming_soon',
     },
-    state.dependencies,
+    state,
   )
-
-  assert.deepEqual(result, { status: 200, body: { ok: true } })
   assert.deepEqual(state.savedEvent(), {
     event_slug: 'event-one',
     title: 'New title',
@@ -449,592 +384,105 @@ test('updating event details saves one normalized gallery record', async () => {
   })
 })
 
-test('creating an invite returns the event-scoped upload link', async () => {
-  const state = createCommandHarness({
-    id: 'guest-photo',
-    event_slug: 'event-one',
-    object_key: 'pending/event-one/guest-photo.jpg',
-    original_filename: 'guest.jpg',
-    width: 1600,
-    height: 900,
-    alt: 'Guest upload',
-    status: 'pending',
-    created_at: 1,
-    published_at: null,
-  })
-
-  const result = await executeGalleryAdminCommand(
+test('creates an event-scoped invite', async () => {
+  const state = createHarness()
+  assert.deepEqual(
+    await run({ action: 'createInvite', guestName: '  Guest Name  ' }, state),
     {
-      event: {
-        id: 'event-one',
-        title: 'Event One',
-        summary: 'Event gallery',
-        category: 'Event Photography',
-        eventDate: null,
-        eventTime: null,
-        eventVenue: null,
-        comingSoon: false,
-        status: 'published',
-        staticPhotos: [],
+      status: 200,
+      body: {
+        ok: true,
+        token: 'generated-id',
+        url: 'https://example.com/galleries/event-one/upload/generated-id/',
       },
-      requestUrl: 'https://example.com/admin/galleries/event-one',
     },
-    { action: 'createInvite', guestName: '  Guest Name  ' },
-    state.dependencies,
   )
-
   assert.deepEqual(state.savedInvite(), {
     token: 'generated-id',
     event_slug: 'event-one',
     guest_name: 'Guest Name',
   })
-  assert.deepEqual(result, {
-    status: 200,
-    body: {
-      ok: true,
-      token: 'generated-id',
-      url: 'https://example.com/galleries/event-one/upload/generated-id/',
-    },
-  })
 })
 
-test('setting a cover accepts only an image from the event gallery', async () => {
-  const state = createCommandHarness({
-    id: 'guest-photo',
-    event_slug: 'event-one',
-    object_key: 'pending/event-one/guest-photo.jpg',
-    original_filename: 'guest.jpg',
-    width: 1600,
-    height: 900,
-    alt: 'Guest upload',
-    status: 'pending',
-    created_at: 1,
-    published_at: null,
-  })
-  const coverSrc = 'https://photos.example/event-one/pro.jpg'
-
-  const result = await executeGalleryAdminCommand(
-    {
-      event: {
-        id: 'event-one',
-        title: 'Event One',
-        summary: 'Event gallery',
-        category: 'Event Photography',
-        eventDate: null,
-        eventTime: null,
-        eventVenue: null,
-        comingSoon: false,
-        status: 'published',
-        staticPhotos: [
-          {
-            src: coverSrc,
-            width: 1200,
-            height: 800,
-            alt: 'Professional photo',
-            filename: 'pro.jpg',
-          },
-        ],
-      },
-      requestUrl: 'https://example.com/admin/galleries/event-one',
-    },
-    {
-      action: 'setCover',
-      src: coverSrc,
-      width: 1200,
-      height: 800,
-      alt: '  Event cover  ',
-    },
-    state.dependencies,
+test('sets a cover from an event photo', async () => {
+  const state = createHarness()
+  const src = 'https://photos.example/event-one/photo.jpg'
+  await run(
+    { action: 'setCover', src, width: 1200, height: 800, alt: ' Cover ' },
+    state,
+    commandContext({ staticPhotos: [{ src, filename: 'photo.jpg' }] }),
   )
-
-  assert.deepEqual(result, { status: 200, body: { ok: true } })
-  assert.deepEqual(state.savedEvent(), {
-    event_slug: 'event-one',
-    title: 'Event One',
-    summary: 'Event gallery',
-    category: 'Event Photography',
-    event_date: null,
-    event_time: null,
-    event_venue: null,
-    coming_soon: false,
-    status: 'published',
-    cover: {
-      src: coverSrc,
-      width: 1200,
-      height: 800,
-      alt: 'Event cover',
-    },
-  })
-})
-
-test('uploading an admin photo stores one optimized gallery photo', async () => {
-  const state = createCommandHarness(
-    {
-      id: 'guest-photo',
-      event_slug: 'event-one',
-      object_key: 'pending/event-one/guest-photo.jpg',
-      original_filename: 'guest.jpg',
-      width: 1600,
-      height: 900,
-      alt: 'Guest upload',
-      status: 'pending',
-      created_at: 1,
-      published_at: null,
-    },
-    {
-      optimized: {
-        buffer: new Uint8Array([4, 5, 6]),
-        width: 1200,
-        height: 800,
-      },
-    },
-  )
-  const file = new File(['photo'], '../Original Photo.PNG', {
-    type: 'image/png',
-  })
-
-  const result = await executeGalleryAdminCommand(
-    {
-      event: {
-        id: 'event-one',
-        title: 'Event One',
-        summary: 'Event gallery',
-        category: 'Event Photography',
-        eventDate: null,
-        eventTime: null,
-        eventVenue: null,
-        comingSoon: false,
-        status: 'published',
-        staticPhotos: [],
-      },
-      requestUrl: 'https://example.com/admin/galleries/event-one',
-    },
-    { action: 'uploadAdminPhoto', file, alt: '  Admin photo  ' },
-    state.dependencies,
-  )
-
-  assert.deepEqual(result, {
-    status: 201,
-    body: { ok: true, id: 'generated-id' },
-  })
-  assert.deepEqual(state.insertedPhoto(), {
-    id: 'generated-id',
-    event_slug: 'event-one',
-    object_key: 'events/event-one/photos/generated-id.jpg',
-    original_filename: 'Original Photo.PNG',
+  assert.deepEqual(state.savedEvent()?.cover, {
+    src,
     width: 1200,
     height: 800,
-    alt: 'Admin photo',
-    uploader_name: null,
-    source: 'admin',
+    alt: 'Cover',
   })
+})
+
+test('uploads an admin photo and compensates insertion failure', async () => {
+  const optimized = { buffer: bytes(), width: 1200, height: 800 }
+  const state = createHarness({ optimized })
   assert.deepEqual(
-    [...state.published.keys()],
-    ['events/event-one/photos/generated-id.jpg'],
-  )
-})
-
-test('replacing a flyer saves matching flyer and cover metadata', async () => {
-  const state = createCommandHarness(
-    {
-      id: 'guest-photo',
-      event_slug: 'event-one',
-      object_key: 'pending/event-one/guest-photo.jpg',
-      original_filename: 'guest.jpg',
-      width: 1600,
-      height: 900,
-      alt: 'Guest upload',
-      status: 'pending',
-      created_at: 1,
-      published_at: null,
-    },
-    {
-      optimized: {
-        buffer: new Uint8Array([7, 8, 9]),
-        width: 900,
-        height: 1200,
-      },
-    },
-  )
-  const file = new File(['flyer'], 'flyer.png', { type: 'image/png' })
-
-  const result = await executeGalleryAdminCommand(
-    {
-      event: {
-        id: 'event-one',
-        title: 'Event One',
-        summary: 'Event gallery',
-        category: 'Community',
-        eventDate: '2026-08-01',
-        eventTime: '18:00',
-        eventVenue: 'Tampa',
-        comingSoon: true,
-        status: 'coming_soon',
-        staticPhotos: [],
-      },
-      requestUrl: 'https://example.com/admin/galleries/event-one',
-    },
-    { action: 'updateFlyer', file },
-    state.dependencies,
-  )
-
-  const objectKey = 'events/event-one/flyer-generated-id.jpg'
-  const flyer = {
-    object_key: objectKey,
-    width: 900,
-    height: 1200,
-    alt: 'Event One flyer',
-  }
-  assert.deepEqual(result, { status: 201, body: { ok: true, flyer } })
-  assert.deepEqual(state.savedEvent(), {
-    event_slug: 'event-one',
-    title: 'Event One',
-    summary: 'Event gallery',
-    category: 'Community',
-    event_date: '2026-08-01',
-    event_time: '18:00',
-    event_venue: 'Tampa',
-    coming_soon: true,
-    status: 'coming_soon',
-    flyer,
-    cover: {
-      src: `https://photos.ayoubabed.xyz/${objectKey}`,
-      width: 900,
-      height: 1200,
-      alt: 'Event One flyer',
-    },
-  })
-  assert.deepEqual([...state.published.keys()], [objectKey])
-})
-
-test('approval remains successful when pending cleanup must be retried', async () => {
-  const failure = new Error('Pending bucket unavailable')
-  const state = createCommandHarness(
-    {
-      id: 'guest-photo',
-      event_slug: 'event-one',
-      object_key: 'pending/event-one/guest-photo.jpg',
-      original_filename: 'guest.jpg',
-      width: 1600,
-      height: 900,
-      alt: 'Guest upload',
-      status: 'pending',
-      created_at: 1,
-      published_at: null,
-    },
-    { deletePendingError: failure },
-  )
-
-  const result = await executeGalleryAdminCommand(
-    commandContext(),
-    { action: 'approveGuest', photoId: 'guest-photo' },
-    state.dependencies,
-  )
-
-  assert.deepEqual(result, { status: 200, body: { ok: true } })
-  assert.equal(state.photo().status, 'published')
-  assert.equal(state.pending.size, 1)
-  assert.equal(
-    state.logs.some(
-      ({ message, objectKey }) =>
-        message === 'gallery guest cleanup failed' &&
-        objectKey === 'pending/event-one/guest-photo.jpg',
-    ),
-    true,
-  )
-})
-
-test('rejection keeps the pending image when deleting its record fails', async () => {
-  const failure = new Error('Database unavailable')
-  const state = createCommandHarness(
-    {
-      id: 'guest-photo',
-      event_slug: 'event-one',
-      object_key: 'pending/event-one/guest-photo.jpg',
-      original_filename: 'guest.jpg',
-      width: 1600,
-      height: 900,
-      alt: 'Guest upload',
-      status: 'pending',
-      created_at: 1,
-      published_at: null,
-    },
-    { deleteGuestError: failure },
-  )
-
-  await assert.rejects(
-    executeGalleryAdminCommand(
-      commandContext(),
-      { action: 'rejectGuest', photoId: 'guest-photo' },
-      state.dependencies,
-    ),
-    failure,
-  )
-  assert.equal(state.pending.size, 1)
-})
-
-test('removing a published guest photo deletes its public image and record', async () => {
-  const state = createCommandHarness({
-    id: 'guest-photo',
-    event_slug: 'event-one',
-    object_key: 'events/event-one/guest/guest-photo.jpg',
-    original_filename: 'guest.jpg',
-    width: 1600,
-    height: 900,
-    alt: 'Guest upload',
-    status: 'published',
-    created_at: 1,
-    published_at: 2,
-  })
-
-  const result = await executeGalleryAdminCommand(
-    commandContext(),
-    { action: 'removeGuest', photoId: 'guest-photo' },
-    state.dependencies,
-  )
-
-  assert.deepEqual(result, { status: 200, body: { ok: true } })
-  assert.equal(state.published.size, 0)
-  assert.equal(state.deleted(), true)
-})
-
-test('published removal restores the public image when deleting its record fails', async () => {
-  const failure = new Error('Database unavailable')
-  const state = createCommandHarness(
-    {
-      id: 'guest-photo',
-      event_slug: 'event-one',
-      object_key: 'events/event-one/guest/guest-photo.jpg',
-      original_filename: 'guest.jpg',
-      width: 1600,
-      height: 900,
-      alt: 'Guest upload',
-      status: 'published',
-      created_at: 1,
-      published_at: 2,
-    },
-    { deleteGuestError: failure },
-  )
-
-  await assert.rejects(
-    executeGalleryAdminCommand(
-      commandContext(),
-      { action: 'removeGuest', photoId: 'guest-photo' },
-      state.dependencies,
-    ),
-    failure,
-  )
-  assert.deepEqual(
-    [...state.published.keys()],
-    ['events/event-one/guest/guest-photo.jpg'],
-  )
-})
-
-test('published removal keeps its record when public deletion fails', async () => {
-  const failure = new Error('Public bucket unavailable')
-  const state = createCommandHarness(
-    {
-      id: 'guest-photo',
-      event_slug: 'event-one',
-      object_key: 'events/event-one/guest/guest-photo.jpg',
-      original_filename: 'guest.jpg',
-      width: 1600,
-      height: 900,
-      alt: 'Guest upload',
-      status: 'published',
-      created_at: 1,
-      published_at: 2,
-    },
-    { deletePublicError: failure },
-  )
-
-  await assert.rejects(
-    executeGalleryAdminCommand(
-      commandContext(),
-      { action: 'removeGuest', photoId: 'guest-photo' },
-      state.dependencies,
-    ),
-    failure,
-  )
-  assert.equal(state.deleted(), false)
-  assert.equal(state.published.size, 1)
-})
-
-test('repeated approval cleans a stale pending object by its deterministic key', async () => {
-  const state = createCommandHarness({
-    id: 'guest-photo',
-    event_slug: 'event-one',
-    object_key: 'events/event-one/guest/guest-photo.jpg',
-    original_filename: 'guest.jpg',
-    width: 1600,
-    height: 900,
-    alt: 'Guest upload',
-    status: 'published',
-    created_at: 1,
-    published_at: 2,
-  })
-  state.pending.set(
-    'pending/event-one/guest-photo.jpg',
-    new Uint8Array([1, 2, 3]),
-  )
-
-  const result = await executeGalleryAdminCommand(
-    commandContext(),
-    { action: 'approveGuest', photoId: 'guest-photo' },
-    state.dependencies,
-  )
-
-  assert.deepEqual(result, { status: 200, body: { ok: true } })
-  assert.equal(state.pending.size, 0)
-})
-
-test('restoring a professional photo reverses its hidden state', async () => {
-  const state = createCommandHarness({
-    id: 'guest-photo',
-    event_slug: 'event-one',
-    object_key: 'pending/event-one/guest-photo.jpg',
-    original_filename: 'guest.jpg',
-    width: 1600,
-    height: 900,
-    alt: 'Guest upload',
-    status: 'pending',
-    created_at: 1,
-    published_at: null,
-  })
-  const context = commandContext({
-    staticPhotos: [
+    await run(
       {
-        src: 'https://photos.example/event-one/pro.jpg',
-        filename: 'pro.jpg',
+        action: 'uploadAdminPhoto',
+        file: new File(['photo'], '../Photo.PNG', { type: 'image/png' }),
+        alt: ' Admin photo ',
       },
-    ],
-  })
-
-  await executeGalleryAdminCommand(
-    context,
-    { action: 'hideProfessional', filename: 'pro.jpg' },
-    state.dependencies,
+      state,
+    ),
+    { status: 201, body: { ok: true, id: 'generated-id' } },
   )
-  await executeGalleryAdminCommand(
-    context,
-    { action: 'restoreProfessional', filename: 'pro.jpg' },
-    state.dependencies,
-  )
+  assert.equal(state.insertedPhoto()?.original_filename, 'Photo.PNG')
+  assert.equal(state.published.size, 1)
 
-  assert.deepEqual([...state.hidden], [])
-})
-
-test('enabling uploads reuses an existing gallery password', async () => {
-  const state = createCommandHarness(
-    {
-      id: 'guest-photo',
-      event_slug: 'event-one',
-      object_key: 'pending/event-one/guest-photo.jpg',
-      original_filename: 'guest.jpg',
-      width: 1600,
-      height: 900,
-      alt: 'Guest upload',
-      status: 'pending',
-      created_at: 1,
-      published_at: null,
-    },
-    {
-      settings: {
-        event_slug: 'event-one',
-        uploads_enabled: 0,
-        password_salt: 'salt',
-        password_hash: 'hash',
-        updated_at: 1,
-      },
-    },
-  )
-
-  await executeGalleryAdminCommand(
-    commandContext(),
-    { action: 'settings', uploadsEnabled: true },
-    state.dependencies,
-  )
-
-  assert.deepEqual(state.savedSettings(), {
-    uploadsEnabled: true,
-    password: undefined,
-  })
-})
-
-test('admin photo upload removes the public object when insertion fails', async () => {
   const failure = new Error('Database unavailable')
-  const state = createCommandHarness(
-    {
-      id: 'guest-photo',
-      event_slug: 'event-one',
-      object_key: 'pending/event-one/guest-photo.jpg',
-      original_filename: 'guest.jpg',
-      width: 1600,
-      height: 900,
-      alt: 'Guest upload',
-      status: 'pending',
-      created_at: 1,
-      published_at: null,
-    },
-    {
-      insertPhotoError: failure,
-      optimized: {
-        buffer: new Uint8Array([4, 5, 6]),
-        width: 1200,
-        height: 800,
-      },
-    },
-  )
-
+  const failed = createHarness({
+    optimized,
+    errors: { insertPhoto: failure },
+  })
   await assert.rejects(
-    executeGalleryAdminCommand(
-      commandContext(),
+    run(
       {
         action: 'uploadAdminPhoto',
         file: new File(['photo'], 'photo.png', { type: 'image/png' }),
       },
-      state.dependencies,
+      failed,
     ),
     failure,
   )
-  assert.equal(state.published.size, 0)
+  assert.equal(failed.published.size, 0)
 })
 
-test('flyer replacement removes the public object when saving fails', async () => {
-  const failure = new Error('Database unavailable')
-  const state = createCommandHarness(
-    {
-      id: 'guest-photo',
-      event_slug: 'event-one',
-      object_key: 'pending/event-one/guest-photo.jpg',
-      original_filename: 'guest.jpg',
-      width: 1600,
-      height: 900,
-      alt: 'Guest upload',
-      status: 'pending',
-      created_at: 1,
-      published_at: null,
-    },
-    {
-      saveEventError: failure,
-      optimized: {
-        buffer: new Uint8Array([7, 8, 9]),
-        width: 900,
-        height: 1200,
-      },
-    },
+test('replaces a flyer and compensates save failure', async () => {
+  const optimized = { buffer: bytes(), width: 900, height: 1200 }
+  const state = createHarness({ optimized })
+  const command = {
+    action: 'updateFlyer',
+    file: new File(['flyer'], 'flyer.png', { type: 'image/png' }),
+  }
+  const result = await run(command, state)
+  assert.equal(result.status, 201)
+  assert.equal(
+    state.savedEvent()?.flyer?.object_key,
+    'events/event-one/flyer-generated-id.jpg',
   )
+  assert.equal(state.published.size, 1)
 
+  const failure = new Error('Database unavailable')
+  const failed = createHarness({
+    optimized,
+    errors: { saveEvent: failure },
+  })
+  await assert.rejects(run(command, failed), failure)
+  assert.equal(failed.published.size, 0)
+})
+
+test('rejects unsupported commands', async () => {
   await assert.rejects(
-    executeGalleryAdminCommand(
-      commandContext(),
-      {
-        action: 'updateFlyer',
-        file: new File(['flyer'], 'flyer.png', { type: 'image/png' }),
-      },
-      state.dependencies,
-    ),
-    failure,
+    run({ action: 'deleteEverything' }, createHarness()),
+    (error) =>
+      error instanceof GalleryAdminCommandError && error.status === 400,
   )
-  assert.equal(state.published.size, 0)
 })

--- a/src/lib/gallery-admin-commands.test.ts
+++ b/src/lib/gallery-admin-commands.test.ts
@@ -1,0 +1,1040 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  executeGalleryAdminCommand,
+  GalleryAdminCommandError,
+  type GalleryAdminCommandContext,
+  type GalleryAdminCommandDependencies,
+  type GalleryAdminEventContext,
+} from './gallery-admin-commands'
+import type {
+  GalleryInvite,
+  GalleryPhoto,
+  GallerySettings,
+  GuestPhoto,
+  SaveEventGalleryInput,
+} from './gallery-data'
+
+function commandContext(
+  event: Partial<GalleryAdminEventContext> = {},
+): GalleryAdminCommandContext {
+  return {
+    event: {
+      id: 'event-one',
+      title: 'Event One',
+      summary: 'Event gallery',
+      category: 'Event Photography',
+      eventDate: null,
+      eventTime: null,
+      eventVenue: null,
+      comingSoon: false,
+      status: 'published',
+      staticPhotos: [],
+      ...event,
+    },
+    requestUrl: 'https://example.com/admin/galleries/event-one',
+  }
+}
+
+function createCommandHarness(
+  photo: GuestPhoto,
+  options: {
+    publishError?: Error
+    deleteGuestError?: Error
+    deletePendingError?: Error
+    deletePublicError?: Error
+    insertPhotoError?: Error
+    saveEventError?: Error
+    settings?: GallerySettings
+    optimized?: { buffer: Uint8Array; width: number; height: number }
+  } = {},
+) {
+  const pending = new Map<string, Uint8Array>(
+    photo.status === 'pending'
+      ? [[photo.object_key, new Uint8Array([1, 2, 3])]]
+      : [],
+  )
+  const published = new Map<string, Uint8Array>(
+    photo.status === 'published'
+      ? [[photo.object_key, new Uint8Array([1, 2, 3])]]
+      : [],
+  )
+  let storedPhoto = photo
+  let deleted = false
+  const hidden = new Set<string>()
+  let savedSettings:
+    | { uploadsEnabled: boolean; password?: { salt: string; hash: string } }
+    | undefined
+  let savedEvent: SaveEventGalleryInput | undefined
+  let savedInvite:
+    Pick<GalleryInvite, 'token' | 'event_slug' | 'guest_name'> | undefined
+  let insertedPhoto: Omit<GalleryPhoto, 'created_at'> | undefined
+  const logs: Array<Record<string, unknown>> = []
+
+  const dependencies: GalleryAdminCommandDependencies = {
+    data: {
+      getSettings: async () => options.settings,
+      saveSettings: async (_eventSlug, uploadsEnabled, password) => {
+        savedSettings = { uploadsEnabled, password }
+      },
+      getGuestPhoto: async () => storedPhoto,
+      publishGuestPhoto: async (photoId, objectKey, alt) => {
+        if (options.publishError) throw options.publishError
+        storedPhoto = {
+          ...storedPhoto,
+          id: photoId,
+          object_key: objectKey,
+          alt,
+          status: 'published',
+          published_at: 1,
+        }
+      },
+      deleteGuestPhoto: async () => {
+        if (options.deleteGuestError) throw options.deleteGuestError
+        deleted = true
+      },
+      hideProfessionalPhoto: async (_eventSlug, filename) => {
+        hidden.add(filename)
+      },
+      restoreProfessionalPhoto: async (_eventSlug, filename) => {
+        hidden.delete(filename)
+      },
+      listGalleryPhotos: async () => [],
+      listGuestPhotos: async () => [storedPhoto],
+      saveEventGallery: async (input) => {
+        if (options.saveEventError) throw options.saveEventError
+        savedEvent = input
+      },
+      createInvite: async (invite) => {
+        savedInvite = invite
+      },
+      insertGalleryPhoto: async (inserted) => {
+        if (options.insertPhotoError) throw options.insertPhotoError
+        insertedPhoto = inserted
+      },
+    },
+    objects: {
+      getPending: async (key) => {
+        const body = pending.get(key)
+        return body ? { body } : undefined
+      },
+      getPublic: async (key) => {
+        const body = published.get(key)
+        return body ? { body } : undefined
+      },
+      publicExists: async (key) => published.has(key),
+      putPublic: async (key, body) => {
+        if (!(body instanceof Uint8Array)) {
+          throw new Error('The test adapter expected a byte array.')
+        }
+        published.set(key, body)
+      },
+      deletePending: async (key) => {
+        if (options.deletePendingError) throw options.deletePendingError
+        pending.delete(key)
+      },
+      putPending: async (key, body) => {
+        if (!(body instanceof Uint8Array)) {
+          throw new Error('The test adapter expected a byte array.')
+        }
+        pending.set(key, body)
+      },
+      deletePublic: async (key) => {
+        if (options.deletePublicError) throw options.deletePublicError
+        published.delete(key)
+      },
+    },
+    images: {
+      optimize: async () => {
+        if (options.optimized) return options.optimized
+        throw new Error('Image optimization was not expected.')
+      },
+    },
+    passwords: {
+      valid: () => true,
+      hash: async () => ({ salt: 'salt', hash: 'hash' }),
+    },
+    createId: () => 'generated-id',
+    log: (entry) => logs.push(entry),
+  }
+
+  return {
+    dependencies,
+    pending,
+    published,
+    photo: () => storedPhoto,
+    deleted: () => deleted,
+    savedSettings: () => savedSettings,
+    hidden,
+    savedEvent: () => savedEvent,
+    savedInvite: () => savedInvite,
+    insertedPhoto: () => insertedPhoto,
+    logs,
+  }
+}
+
+test('approving a guest photo publishes it and removes the pending copy', async () => {
+  const original: GuestPhoto = {
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'pending/event-one/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'pending',
+    created_at: 1,
+    published_at: null,
+  }
+  const state = createCommandHarness(original)
+
+  const result = await executeGalleryAdminCommand(
+    {
+      event: {
+        id: 'event-one',
+        title: 'Event One',
+        summary: 'Event gallery',
+        category: 'Event Photography',
+        eventDate: null,
+        eventTime: null,
+        eventVenue: null,
+        comingSoon: false,
+        status: 'published',
+        staticPhotos: [],
+      },
+      requestUrl: 'https://example.com/admin/galleries/event-one',
+    },
+    { action: 'approveGuest', photoId: 'guest-photo', alt: 'Approved' },
+    state.dependencies,
+  )
+
+  assert.deepEqual(result, { status: 200, body: { ok: true } })
+  assert.equal(state.pending.size, 0)
+  assert.deepEqual(
+    [...state.published.keys()],
+    ['events/event-one/guest/guest-photo.jpg'],
+  )
+  assert.equal(state.photo().status, 'published')
+  assert.equal(state.photo().alt, 'Approved')
+})
+
+test('approval removes a copied public image when the database update fails', async () => {
+  const original: GuestPhoto = {
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'pending/event-one/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'pending',
+    created_at: 1,
+    published_at: null,
+  }
+  const failure = new Error('Database unavailable')
+  const state = createCommandHarness(original, { publishError: failure })
+
+  await assert.rejects(
+    executeGalleryAdminCommand(
+      {
+        event: {
+          id: 'event-one',
+          title: 'Event One',
+          summary: 'Event gallery',
+          category: 'Event Photography',
+          eventDate: null,
+          eventTime: null,
+          eventVenue: null,
+          comingSoon: false,
+          status: 'published',
+          staticPhotos: [],
+        },
+        requestUrl: 'https://example.com/admin/galleries/event-one',
+      },
+      { action: 'approveGuest', photoId: 'guest-photo' },
+      state.dependencies,
+    ),
+    failure,
+  )
+
+  assert.equal(state.published.size, 0)
+  assert.equal(state.pending.size, 1)
+  assert.equal(state.photo().status, 'pending')
+})
+
+test('rejecting a pending guest photo removes its image and record', async () => {
+  const original: GuestPhoto = {
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'pending/event-one/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'pending',
+    created_at: 1,
+    published_at: null,
+  }
+  const state = createCommandHarness(original)
+
+  const result = await executeGalleryAdminCommand(
+    {
+      event: {
+        id: 'event-one',
+        title: 'Event One',
+        summary: 'Event gallery',
+        category: 'Event Photography',
+        eventDate: null,
+        eventTime: null,
+        eventVenue: null,
+        comingSoon: false,
+        status: 'published',
+        staticPhotos: [],
+      },
+      requestUrl: 'https://example.com/admin/galleries/event-one',
+    },
+    { action: 'rejectGuest', photoId: 'guest-photo' },
+    state.dependencies,
+  )
+
+  assert.deepEqual(result, { status: 200, body: { ok: true } })
+  assert.equal(state.pending.size, 0)
+  assert.equal(state.deleted(), true)
+})
+
+test('uploads cannot be enabled before the gallery has a password', async () => {
+  const state = createCommandHarness({
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'pending/event-one/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'pending',
+    created_at: 1,
+    published_at: null,
+  })
+
+  await assert.rejects(
+    executeGalleryAdminCommand(
+      {
+        event: {
+          id: 'event-one',
+          title: 'Event One',
+          summary: 'Event gallery',
+          category: 'Event Photography',
+          eventDate: null,
+          eventTime: null,
+          eventVenue: null,
+          comingSoon: false,
+          status: 'published',
+          staticPhotos: [],
+        },
+        requestUrl: 'https://example.com/admin/galleries/event-one',
+      },
+      { action: 'settings', uploadsEnabled: true },
+      state.dependencies,
+    ),
+    (error) =>
+      error instanceof GalleryAdminCommandError &&
+      error.status === 400 &&
+      error.message === 'Set a password before enabling uploads.',
+  )
+  assert.equal(state.savedSettings(), undefined)
+})
+
+test('hiding a professional photo validates it against the event gallery', async () => {
+  const state = createCommandHarness({
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'pending/event-one/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'pending',
+    created_at: 1,
+    published_at: null,
+  })
+
+  const result = await executeGalleryAdminCommand(
+    {
+      event: {
+        id: 'event-one',
+        title: 'Event One',
+        summary: 'Event gallery',
+        category: 'Event Photography',
+        eventDate: null,
+        eventTime: null,
+        eventVenue: null,
+        comingSoon: false,
+        status: 'published',
+        staticPhotos: [
+          {
+            src: 'https://photos.example/event-one/pro.jpg',
+            width: 1200,
+            height: 800,
+            alt: 'Professional photo',
+            filename: 'pro.jpg',
+          },
+        ],
+      },
+      requestUrl: 'https://example.com/admin/galleries/event-one',
+    },
+    { action: 'hideProfessional', filename: 'pro.jpg' },
+    state.dependencies,
+  )
+
+  assert.deepEqual(result, { status: 200, body: { ok: true } })
+  assert.deepEqual([...state.hidden], ['pro.jpg'])
+})
+
+test('updating event details saves one normalized gallery record', async () => {
+  const state = createCommandHarness({
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'pending/event-one/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'pending',
+    created_at: 1,
+    published_at: null,
+  })
+
+  const result = await executeGalleryAdminCommand(
+    {
+      event: {
+        id: 'event-one',
+        title: 'Old title',
+        summary: 'Old summary',
+        category: 'Event Photography',
+        eventDate: null,
+        eventTime: null,
+        eventVenue: null,
+        comingSoon: false,
+        status: 'published',
+        staticPhotos: [],
+      },
+      requestUrl: 'https://example.com/admin/galleries/event-one',
+    },
+    {
+      action: 'updateEvent',
+      title: '  New title  ',
+      summary: '  New summary  ',
+      eventDate: '2026-08-01',
+      eventTime: '18:00',
+      eventVenue: 'Tampa',
+      category: 'Community',
+      comingSoon: true,
+      visibilityStatus: 'coming_soon',
+    },
+    state.dependencies,
+  )
+
+  assert.deepEqual(result, { status: 200, body: { ok: true } })
+  assert.deepEqual(state.savedEvent(), {
+    event_slug: 'event-one',
+    title: 'New title',
+    summary: 'New summary',
+    event_date: '2026-08-01',
+    event_time: '18:00',
+    event_venue: 'Tampa',
+    category: 'Community',
+    coming_soon: true,
+    status: 'coming_soon',
+  })
+})
+
+test('creating an invite returns the event-scoped upload link', async () => {
+  const state = createCommandHarness({
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'pending/event-one/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'pending',
+    created_at: 1,
+    published_at: null,
+  })
+
+  const result = await executeGalleryAdminCommand(
+    {
+      event: {
+        id: 'event-one',
+        title: 'Event One',
+        summary: 'Event gallery',
+        category: 'Event Photography',
+        eventDate: null,
+        eventTime: null,
+        eventVenue: null,
+        comingSoon: false,
+        status: 'published',
+        staticPhotos: [],
+      },
+      requestUrl: 'https://example.com/admin/galleries/event-one',
+    },
+    { action: 'createInvite', guestName: '  Guest Name  ' },
+    state.dependencies,
+  )
+
+  assert.deepEqual(state.savedInvite(), {
+    token: 'generated-id',
+    event_slug: 'event-one',
+    guest_name: 'Guest Name',
+  })
+  assert.deepEqual(result, {
+    status: 200,
+    body: {
+      ok: true,
+      token: 'generated-id',
+      url: 'https://example.com/galleries/event-one/upload/generated-id/',
+    },
+  })
+})
+
+test('setting a cover accepts only an image from the event gallery', async () => {
+  const state = createCommandHarness({
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'pending/event-one/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'pending',
+    created_at: 1,
+    published_at: null,
+  })
+  const coverSrc = 'https://photos.example/event-one/pro.jpg'
+
+  const result = await executeGalleryAdminCommand(
+    {
+      event: {
+        id: 'event-one',
+        title: 'Event One',
+        summary: 'Event gallery',
+        category: 'Event Photography',
+        eventDate: null,
+        eventTime: null,
+        eventVenue: null,
+        comingSoon: false,
+        status: 'published',
+        staticPhotos: [
+          {
+            src: coverSrc,
+            width: 1200,
+            height: 800,
+            alt: 'Professional photo',
+            filename: 'pro.jpg',
+          },
+        ],
+      },
+      requestUrl: 'https://example.com/admin/galleries/event-one',
+    },
+    {
+      action: 'setCover',
+      src: coverSrc,
+      width: 1200,
+      height: 800,
+      alt: '  Event cover  ',
+    },
+    state.dependencies,
+  )
+
+  assert.deepEqual(result, { status: 200, body: { ok: true } })
+  assert.deepEqual(state.savedEvent(), {
+    event_slug: 'event-one',
+    title: 'Event One',
+    summary: 'Event gallery',
+    category: 'Event Photography',
+    event_date: null,
+    event_time: null,
+    event_venue: null,
+    coming_soon: false,
+    status: 'published',
+    cover: {
+      src: coverSrc,
+      width: 1200,
+      height: 800,
+      alt: 'Event cover',
+    },
+  })
+})
+
+test('uploading an admin photo stores one optimized gallery photo', async () => {
+  const state = createCommandHarness(
+    {
+      id: 'guest-photo',
+      event_slug: 'event-one',
+      object_key: 'pending/event-one/guest-photo.jpg',
+      original_filename: 'guest.jpg',
+      width: 1600,
+      height: 900,
+      alt: 'Guest upload',
+      status: 'pending',
+      created_at: 1,
+      published_at: null,
+    },
+    {
+      optimized: {
+        buffer: new Uint8Array([4, 5, 6]),
+        width: 1200,
+        height: 800,
+      },
+    },
+  )
+  const file = new File(['photo'], '../Original Photo.PNG', {
+    type: 'image/png',
+  })
+
+  const result = await executeGalleryAdminCommand(
+    {
+      event: {
+        id: 'event-one',
+        title: 'Event One',
+        summary: 'Event gallery',
+        category: 'Event Photography',
+        eventDate: null,
+        eventTime: null,
+        eventVenue: null,
+        comingSoon: false,
+        status: 'published',
+        staticPhotos: [],
+      },
+      requestUrl: 'https://example.com/admin/galleries/event-one',
+    },
+    { action: 'uploadAdminPhoto', file, alt: '  Admin photo  ' },
+    state.dependencies,
+  )
+
+  assert.deepEqual(result, {
+    status: 201,
+    body: { ok: true, id: 'generated-id' },
+  })
+  assert.deepEqual(state.insertedPhoto(), {
+    id: 'generated-id',
+    event_slug: 'event-one',
+    object_key: 'events/event-one/photos/generated-id.jpg',
+    original_filename: 'Original Photo.PNG',
+    width: 1200,
+    height: 800,
+    alt: 'Admin photo',
+    uploader_name: null,
+    source: 'admin',
+  })
+  assert.deepEqual(
+    [...state.published.keys()],
+    ['events/event-one/photos/generated-id.jpg'],
+  )
+})
+
+test('replacing a flyer saves matching flyer and cover metadata', async () => {
+  const state = createCommandHarness(
+    {
+      id: 'guest-photo',
+      event_slug: 'event-one',
+      object_key: 'pending/event-one/guest-photo.jpg',
+      original_filename: 'guest.jpg',
+      width: 1600,
+      height: 900,
+      alt: 'Guest upload',
+      status: 'pending',
+      created_at: 1,
+      published_at: null,
+    },
+    {
+      optimized: {
+        buffer: new Uint8Array([7, 8, 9]),
+        width: 900,
+        height: 1200,
+      },
+    },
+  )
+  const file = new File(['flyer'], 'flyer.png', { type: 'image/png' })
+
+  const result = await executeGalleryAdminCommand(
+    {
+      event: {
+        id: 'event-one',
+        title: 'Event One',
+        summary: 'Event gallery',
+        category: 'Community',
+        eventDate: '2026-08-01',
+        eventTime: '18:00',
+        eventVenue: 'Tampa',
+        comingSoon: true,
+        status: 'coming_soon',
+        staticPhotos: [],
+      },
+      requestUrl: 'https://example.com/admin/galleries/event-one',
+    },
+    { action: 'updateFlyer', file },
+    state.dependencies,
+  )
+
+  const objectKey = 'events/event-one/flyer-generated-id.jpg'
+  const flyer = {
+    object_key: objectKey,
+    width: 900,
+    height: 1200,
+    alt: 'Event One flyer',
+  }
+  assert.deepEqual(result, { status: 201, body: { ok: true, flyer } })
+  assert.deepEqual(state.savedEvent(), {
+    event_slug: 'event-one',
+    title: 'Event One',
+    summary: 'Event gallery',
+    category: 'Community',
+    event_date: '2026-08-01',
+    event_time: '18:00',
+    event_venue: 'Tampa',
+    coming_soon: true,
+    status: 'coming_soon',
+    flyer,
+    cover: {
+      src: `https://photos.ayoubabed.xyz/${objectKey}`,
+      width: 900,
+      height: 1200,
+      alt: 'Event One flyer',
+    },
+  })
+  assert.deepEqual([...state.published.keys()], [objectKey])
+})
+
+test('approval remains successful when pending cleanup must be retried', async () => {
+  const failure = new Error('Pending bucket unavailable')
+  const state = createCommandHarness(
+    {
+      id: 'guest-photo',
+      event_slug: 'event-one',
+      object_key: 'pending/event-one/guest-photo.jpg',
+      original_filename: 'guest.jpg',
+      width: 1600,
+      height: 900,
+      alt: 'Guest upload',
+      status: 'pending',
+      created_at: 1,
+      published_at: null,
+    },
+    { deletePendingError: failure },
+  )
+
+  const result = await executeGalleryAdminCommand(
+    commandContext(),
+    { action: 'approveGuest', photoId: 'guest-photo' },
+    state.dependencies,
+  )
+
+  assert.deepEqual(result, { status: 200, body: { ok: true } })
+  assert.equal(state.photo().status, 'published')
+  assert.equal(state.pending.size, 1)
+  assert.equal(
+    state.logs.some(
+      ({ message, objectKey }) =>
+        message === 'gallery guest cleanup failed' &&
+        objectKey === 'pending/event-one/guest-photo.jpg',
+    ),
+    true,
+  )
+})
+
+test('rejection keeps the pending image when deleting its record fails', async () => {
+  const failure = new Error('Database unavailable')
+  const state = createCommandHarness(
+    {
+      id: 'guest-photo',
+      event_slug: 'event-one',
+      object_key: 'pending/event-one/guest-photo.jpg',
+      original_filename: 'guest.jpg',
+      width: 1600,
+      height: 900,
+      alt: 'Guest upload',
+      status: 'pending',
+      created_at: 1,
+      published_at: null,
+    },
+    { deleteGuestError: failure },
+  )
+
+  await assert.rejects(
+    executeGalleryAdminCommand(
+      commandContext(),
+      { action: 'rejectGuest', photoId: 'guest-photo' },
+      state.dependencies,
+    ),
+    failure,
+  )
+  assert.equal(state.pending.size, 1)
+})
+
+test('removing a published guest photo deletes its public image and record', async () => {
+  const state = createCommandHarness({
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'events/event-one/guest/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'published',
+    created_at: 1,
+    published_at: 2,
+  })
+
+  const result = await executeGalleryAdminCommand(
+    commandContext(),
+    { action: 'removeGuest', photoId: 'guest-photo' },
+    state.dependencies,
+  )
+
+  assert.deepEqual(result, { status: 200, body: { ok: true } })
+  assert.equal(state.published.size, 0)
+  assert.equal(state.deleted(), true)
+})
+
+test('published removal restores the public image when deleting its record fails', async () => {
+  const failure = new Error('Database unavailable')
+  const state = createCommandHarness(
+    {
+      id: 'guest-photo',
+      event_slug: 'event-one',
+      object_key: 'events/event-one/guest/guest-photo.jpg',
+      original_filename: 'guest.jpg',
+      width: 1600,
+      height: 900,
+      alt: 'Guest upload',
+      status: 'published',
+      created_at: 1,
+      published_at: 2,
+    },
+    { deleteGuestError: failure },
+  )
+
+  await assert.rejects(
+    executeGalleryAdminCommand(
+      commandContext(),
+      { action: 'removeGuest', photoId: 'guest-photo' },
+      state.dependencies,
+    ),
+    failure,
+  )
+  assert.deepEqual(
+    [...state.published.keys()],
+    ['events/event-one/guest/guest-photo.jpg'],
+  )
+})
+
+test('published removal keeps its record when public deletion fails', async () => {
+  const failure = new Error('Public bucket unavailable')
+  const state = createCommandHarness(
+    {
+      id: 'guest-photo',
+      event_slug: 'event-one',
+      object_key: 'events/event-one/guest/guest-photo.jpg',
+      original_filename: 'guest.jpg',
+      width: 1600,
+      height: 900,
+      alt: 'Guest upload',
+      status: 'published',
+      created_at: 1,
+      published_at: 2,
+    },
+    { deletePublicError: failure },
+  )
+
+  await assert.rejects(
+    executeGalleryAdminCommand(
+      commandContext(),
+      { action: 'removeGuest', photoId: 'guest-photo' },
+      state.dependencies,
+    ),
+    failure,
+  )
+  assert.equal(state.deleted(), false)
+  assert.equal(state.published.size, 1)
+})
+
+test('repeated approval cleans a stale pending object by its deterministic key', async () => {
+  const state = createCommandHarness({
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'events/event-one/guest/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'published',
+    created_at: 1,
+    published_at: 2,
+  })
+  state.pending.set(
+    'pending/event-one/guest-photo.jpg',
+    new Uint8Array([1, 2, 3]),
+  )
+
+  const result = await executeGalleryAdminCommand(
+    commandContext(),
+    { action: 'approveGuest', photoId: 'guest-photo' },
+    state.dependencies,
+  )
+
+  assert.deepEqual(result, { status: 200, body: { ok: true } })
+  assert.equal(state.pending.size, 0)
+})
+
+test('restoring a professional photo reverses its hidden state', async () => {
+  const state = createCommandHarness({
+    id: 'guest-photo',
+    event_slug: 'event-one',
+    object_key: 'pending/event-one/guest-photo.jpg',
+    original_filename: 'guest.jpg',
+    width: 1600,
+    height: 900,
+    alt: 'Guest upload',
+    status: 'pending',
+    created_at: 1,
+    published_at: null,
+  })
+  const context = commandContext({
+    staticPhotos: [
+      {
+        src: 'https://photos.example/event-one/pro.jpg',
+        filename: 'pro.jpg',
+      },
+    ],
+  })
+
+  await executeGalleryAdminCommand(
+    context,
+    { action: 'hideProfessional', filename: 'pro.jpg' },
+    state.dependencies,
+  )
+  await executeGalleryAdminCommand(
+    context,
+    { action: 'restoreProfessional', filename: 'pro.jpg' },
+    state.dependencies,
+  )
+
+  assert.deepEqual([...state.hidden], [])
+})
+
+test('enabling uploads reuses an existing gallery password', async () => {
+  const state = createCommandHarness(
+    {
+      id: 'guest-photo',
+      event_slug: 'event-one',
+      object_key: 'pending/event-one/guest-photo.jpg',
+      original_filename: 'guest.jpg',
+      width: 1600,
+      height: 900,
+      alt: 'Guest upload',
+      status: 'pending',
+      created_at: 1,
+      published_at: null,
+    },
+    {
+      settings: {
+        event_slug: 'event-one',
+        uploads_enabled: 0,
+        password_salt: 'salt',
+        password_hash: 'hash',
+        updated_at: 1,
+      },
+    },
+  )
+
+  await executeGalleryAdminCommand(
+    commandContext(),
+    { action: 'settings', uploadsEnabled: true },
+    state.dependencies,
+  )
+
+  assert.deepEqual(state.savedSettings(), {
+    uploadsEnabled: true,
+    password: undefined,
+  })
+})
+
+test('admin photo upload removes the public object when insertion fails', async () => {
+  const failure = new Error('Database unavailable')
+  const state = createCommandHarness(
+    {
+      id: 'guest-photo',
+      event_slug: 'event-one',
+      object_key: 'pending/event-one/guest-photo.jpg',
+      original_filename: 'guest.jpg',
+      width: 1600,
+      height: 900,
+      alt: 'Guest upload',
+      status: 'pending',
+      created_at: 1,
+      published_at: null,
+    },
+    {
+      insertPhotoError: failure,
+      optimized: {
+        buffer: new Uint8Array([4, 5, 6]),
+        width: 1200,
+        height: 800,
+      },
+    },
+  )
+
+  await assert.rejects(
+    executeGalleryAdminCommand(
+      commandContext(),
+      {
+        action: 'uploadAdminPhoto',
+        file: new File(['photo'], 'photo.png', { type: 'image/png' }),
+      },
+      state.dependencies,
+    ),
+    failure,
+  )
+  assert.equal(state.published.size, 0)
+})
+
+test('flyer replacement removes the public object when saving fails', async () => {
+  const failure = new Error('Database unavailable')
+  const state = createCommandHarness(
+    {
+      id: 'guest-photo',
+      event_slug: 'event-one',
+      object_key: 'pending/event-one/guest-photo.jpg',
+      original_filename: 'guest.jpg',
+      width: 1600,
+      height: 900,
+      alt: 'Guest upload',
+      status: 'pending',
+      created_at: 1,
+      published_at: null,
+    },
+    {
+      saveEventError: failure,
+      optimized: {
+        buffer: new Uint8Array([7, 8, 9]),
+        width: 900,
+        height: 1200,
+      },
+    },
+  )
+
+  await assert.rejects(
+    executeGalleryAdminCommand(
+      commandContext(),
+      {
+        action: 'updateFlyer',
+        file: new File(['flyer'], 'flyer.png', { type: 'image/png' }),
+      },
+      state.dependencies,
+    ),
+    failure,
+  )
+  assert.equal(state.published.size, 0)
+})

--- a/src/lib/gallery-admin-commands.ts
+++ b/src/lib/gallery-admin-commands.ts
@@ -1,0 +1,614 @@
+import {
+  parseGalleryAdminAction,
+  type GalleryAdminAction,
+} from './gallery-admin'
+import { hashGalleryPassword, validGalleryPassword } from './gallery-auth'
+import {
+  GALLERY_PUBLIC_ORIGIN,
+  adminPhotoKey,
+  createGalleryInvite,
+  deleteGuestPhoto,
+  galleryStatus,
+  getGallerySettings,
+  getGuestPhoto,
+  hideProfessionalPhoto,
+  insertGalleryPhoto,
+  listGalleryPhotos,
+  listGuestPhotos,
+  pendingGuestKey,
+  publishGuestPhoto,
+  publishedGuestKey,
+  restoreProfessionalPhoto,
+  saveEventGallery,
+  saveGallerySettings,
+  type GalleryInvite,
+  type GalleryPhoto,
+  type GallerySettings,
+  type GalleryStatus,
+  type GuestPhoto,
+  type SaveEventGalleryInput,
+} from './gallery-data'
+import {
+  acceptedGalleryImage,
+  optimizedGalleryImage,
+  safeGalleryFilename,
+} from './gallery-upload'
+
+type GalleryAdminObjectBody = Parameters<R2Bucket['put']>[1]
+
+type GalleryAdminPassword = { salt: string; hash: string }
+
+export type GalleryAdminEventContext = {
+  id: string
+  title: string
+  summary: string
+  category: string
+  eventDate: string | null
+  eventTime: string | null
+  eventVenue: string | null
+  comingSoon: boolean
+  status: GalleryStatus
+  flyerSrc?: string
+  coverSrc?: string
+  staticPhotos: Array<{
+    src: unknown
+    width?: number
+    height?: number
+    alt?: string
+    filename: string
+  }>
+}
+
+export type GalleryAdminCommandDependencies = {
+  data: {
+    getSettings(eventSlug: string): Promise<GallerySettings | null | undefined>
+    saveSettings(
+      eventSlug: string,
+      uploadsEnabled: boolean,
+      password?: GalleryAdminPassword,
+    ): Promise<unknown>
+    getGuestPhoto(photoId: string): Promise<GuestPhoto | null | undefined>
+    publishGuestPhoto(
+      photoId: string,
+      objectKey: string,
+      alt: string,
+    ): Promise<unknown>
+    deleteGuestPhoto(photoId: string): Promise<unknown>
+    hideProfessionalPhoto(eventSlug: string, filename: string): Promise<unknown>
+    restoreProfessionalPhoto(
+      eventSlug: string,
+      filename: string,
+    ): Promise<unknown>
+    listGalleryPhotos(eventSlug: string): Promise<GalleryPhoto[]>
+    listGuestPhotos(eventSlug: string): Promise<GuestPhoto[]>
+    saveEventGallery(input: SaveEventGalleryInput): Promise<unknown>
+    createInvite(
+      invite: Pick<GalleryInvite, 'token' | 'event_slug' | 'guest_name'>,
+    ): Promise<unknown>
+    insertGalleryPhoto(
+      photo: Omit<GalleryPhoto, 'created_at'>,
+    ): Promise<unknown>
+  }
+  objects: {
+    getPending(
+      key: string,
+    ): Promise<
+      { body: GalleryAdminObjectBody; metadata?: R2HTTPMetadata } | undefined
+    >
+    getPublic(
+      key: string,
+    ): Promise<
+      { body: GalleryAdminObjectBody; metadata?: R2HTTPMetadata } | undefined
+    >
+    publicExists(key: string): Promise<boolean>
+    putPublic(
+      key: string,
+      body: GalleryAdminObjectBody,
+      metadata?: R2HTTPMetadata,
+    ): Promise<unknown>
+    deletePending(key: string): Promise<unknown>
+    putPending(
+      key: string,
+      body: GalleryAdminObjectBody,
+      metadata?: R2HTTPMetadata,
+    ): Promise<unknown>
+    deletePublic(key: string): Promise<unknown>
+  }
+  images: {
+    optimize(file: File): Promise<{
+      buffer: GalleryAdminObjectBody
+      width: number
+      height: number
+    }>
+  }
+  passwords: {
+    valid(password: string): boolean
+    hash(password: string): Promise<GalleryAdminPassword>
+  }
+  createId(): string
+  log(entry: Record<string, unknown>): void
+}
+
+export type GalleryAdminCommandContext = {
+  event: GalleryAdminEventContext
+  requestUrl: string
+}
+
+export type GalleryAdminCommandResult = {
+  status: number
+  body: Record<string, unknown>
+}
+
+export class GalleryAdminCommandError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message)
+  }
+}
+
+export function createGalleryAdminCommandDependencies(bindings: {
+  database: D1Database
+  pendingBucket: R2Bucket
+  publicBucket: R2Bucket
+  images: ImagesBinding
+}): GalleryAdminCommandDependencies {
+  return {
+    data: {
+      getSettings: (eventSlug) =>
+        getGallerySettings(bindings.database, eventSlug),
+      saveSettings: (eventSlug, uploadsEnabled, password) =>
+        saveGallerySettings(
+          bindings.database,
+          eventSlug,
+          uploadsEnabled,
+          password,
+        ),
+      getGuestPhoto: (photoId) => getGuestPhoto(bindings.database, photoId),
+      publishGuestPhoto: (photoId, objectKey, alt) =>
+        publishGuestPhoto(bindings.database, photoId, objectKey, alt),
+      deleteGuestPhoto: (photoId) =>
+        deleteGuestPhoto(bindings.database, photoId),
+      hideProfessionalPhoto: (eventSlug, filename) =>
+        hideProfessionalPhoto(bindings.database, eventSlug, filename),
+      restoreProfessionalPhoto: (eventSlug, filename) =>
+        restoreProfessionalPhoto(bindings.database, eventSlug, filename),
+      listGalleryPhotos: (eventSlug) =>
+        listGalleryPhotos(bindings.database, eventSlug),
+      listGuestPhotos: (eventSlug) =>
+        listGuestPhotos(bindings.database, eventSlug),
+      saveEventGallery: (input) => saveEventGallery(bindings.database, input),
+      createInvite: (invite) => createGalleryInvite(bindings.database, invite),
+      insertGalleryPhoto: (photo) =>
+        insertGalleryPhoto(bindings.database, photo),
+    },
+    objects: {
+      getPending: async (key) => {
+        const object = await bindings.pendingBucket.get(key)
+        return object
+          ? { body: object.body, metadata: object.httpMetadata }
+          : undefined
+      },
+      getPublic: async (key) => {
+        const object = await bindings.publicBucket.get(key)
+        return object
+          ? { body: object.body, metadata: object.httpMetadata }
+          : undefined
+      },
+      publicExists: async (key) =>
+        Boolean(await bindings.publicBucket.head(key)),
+      putPublic: (key, body, metadata) =>
+        bindings.publicBucket.put(key, body, {
+          httpMetadata: metadata,
+        }),
+      deletePending: (key) => bindings.pendingBucket.delete(key),
+      putPending: (key, body, metadata) =>
+        bindings.pendingBucket.put(key, body, { httpMetadata: metadata }),
+      deletePublic: (key) => bindings.publicBucket.delete(key),
+    },
+    images: {
+      optimize: (file) => optimizedGalleryImage(file, bindings.images),
+    },
+    passwords: {
+      valid: validGalleryPassword,
+      hash: hashGalleryPassword,
+    },
+    createId: () => crypto.randomUUID(),
+    log: (entry) => console.log(JSON.stringify(entry)),
+  }
+}
+
+const ok = (body: Record<string, unknown> = { ok: true }) => ({
+  status: 200,
+  body,
+})
+
+function currentEventInput(
+  event: GalleryAdminEventContext,
+): SaveEventGalleryInput {
+  return {
+    event_slug: event.id,
+    title: event.title,
+    summary: event.summary,
+    category: event.category,
+    event_date: event.eventDate,
+    event_time: event.eventTime,
+    event_venue: event.eventVenue,
+    coming_soon: event.comingSoon,
+    status: event.status,
+  }
+}
+
+async function moderateGuestPhoto(
+  context: GalleryAdminCommandContext,
+  action: Extract<GalleryAdminAction, { photoId: string }>,
+  dependencies: GalleryAdminCommandDependencies,
+): Promise<GalleryAdminCommandResult> {
+  const photo = await dependencies.data.getGuestPhoto(action.photoId)
+  if (!photo || photo.event_slug !== context.event.id) {
+    throw new GalleryAdminCommandError('Photo not found.', 404)
+  }
+
+  if (action.action !== 'approveGuest') {
+    if (action.action === 'rejectGuest' && photo.status !== 'pending') {
+      throw new GalleryAdminCommandError(
+        'Published photos must be removed instead.',
+        409,
+      )
+    }
+    const storedObject =
+      photo.status === 'pending'
+        ? await dependencies.objects.getPending(photo.object_key)
+        : await dependencies.objects.getPublic(photo.object_key)
+    if (photo.status === 'pending') {
+      await dependencies.objects.deletePending(photo.object_key)
+    } else {
+      await dependencies.objects.deletePublic(photo.object_key)
+    }
+    try {
+      await dependencies.data.deleteGuestPhoto(photo.id)
+    } catch (error) {
+      if (storedObject) {
+        if (photo.status === 'pending') {
+          await dependencies.objects.putPending(
+            photo.object_key,
+            storedObject.body,
+            storedObject.metadata,
+          )
+        } else {
+          await dependencies.objects.putPublic(
+            photo.object_key,
+            storedObject.body,
+            storedObject.metadata,
+          )
+        }
+      }
+      throw error
+    }
+    dependencies.log({
+      message: 'gallery guest moderation completed',
+      eventSlug: context.event.id,
+      action: action.action,
+      photoId: photo.id,
+    })
+    return ok()
+  }
+
+  if (photo.status === 'published') {
+    const stalePendingKey = pendingGuestKey(context.event.id, photo.id)
+    try {
+      await dependencies.objects.deletePending(stalePendingKey)
+    } catch (error) {
+      dependencies.log({
+        message: 'gallery guest cleanup failed',
+        eventSlug: context.event.id,
+        action: action.action,
+        photoId: photo.id,
+        objectKey: stalePendingKey,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+    return ok()
+  }
+
+  const publicKey = publishedGuestKey(context.event.id, photo.id)
+  const pending = await dependencies.objects.getPending(photo.object_key)
+  let copied = false
+  if (pending) {
+    await dependencies.objects.putPublic(
+      publicKey,
+      pending.body,
+      pending.metadata ?? {
+        contentType: 'image/jpeg',
+        cacheControl: 'public, max-age=300',
+      },
+    )
+    copied = true
+  } else if (!(await dependencies.objects.publicExists(publicKey))) {
+    throw new GalleryAdminCommandError('Pending image is missing.', 409)
+  }
+
+  const alt = action.alt?.trim().slice(0, 240) || photo.alt
+  try {
+    await dependencies.data.publishGuestPhoto(photo.id, publicKey, alt)
+  } catch (error) {
+    if (copied) await dependencies.objects.deletePublic(publicKey)
+    throw error
+  }
+  try {
+    await dependencies.objects.deletePending(photo.object_key)
+  } catch (error) {
+    dependencies.log({
+      message: 'gallery guest cleanup failed',
+      eventSlug: context.event.id,
+      action: action.action,
+      photoId: photo.id,
+      objectKey: photo.object_key,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    })
+  }
+  dependencies.log({
+    message: 'gallery guest moderation completed',
+    eventSlug: context.event.id,
+    action: action.action,
+    photoId: photo.id,
+  })
+  return ok()
+}
+
+export async function executeGalleryAdminCommand(
+  context: GalleryAdminCommandContext,
+  value: unknown,
+  dependencies: GalleryAdminCommandDependencies,
+): Promise<GalleryAdminCommandResult> {
+  const input =
+    value && typeof value === 'object'
+      ? (value as Record<string, unknown>)
+      : undefined
+
+  if (input?.action === 'updateEvent') {
+    const title = typeof input.title === 'string' ? input.title.trim() : ''
+    const summary =
+      typeof input.summary === 'string' ? input.summary.trim() : ''
+    if (!title || !summary) {
+      throw new GalleryAdminCommandError(
+        'Name and about information are required.',
+        400,
+      )
+    }
+    await dependencies.data.saveEventGallery({
+      event_slug: context.event.id,
+      title,
+      event_date:
+        typeof input.eventDate === 'string' && input.eventDate
+          ? input.eventDate
+          : null,
+      event_time:
+        typeof input.eventTime === 'string' && input.eventTime
+          ? input.eventTime
+          : null,
+      event_venue:
+        typeof input.eventVenue === 'string' && input.eventVenue
+          ? input.eventVenue
+          : null,
+      summary,
+      category:
+        typeof input.category === 'string' && input.category.trim()
+          ? input.category.trim()
+          : 'Event Photography',
+      coming_soon: Boolean(input.comingSoon),
+      status:
+        galleryStatus(input.visibilityStatus) ??
+        (input.comingSoon ? 'coming_soon' : 'published'),
+    })
+    return ok()
+  }
+
+  if (input?.action === 'createInvite') {
+    const guestName =
+      typeof input.guestName === 'string' ? input.guestName.trim() : ''
+    if (!guestName) {
+      throw new GalleryAdminCommandError('Guest name is required.', 400)
+    }
+    const token = dependencies.createId()
+    await dependencies.data.createInvite({
+      token,
+      event_slug: context.event.id,
+      guest_name: guestName.slice(0, 120),
+    })
+    return ok({
+      ok: true,
+      token,
+      url: new URL(
+        `/galleries/${context.event.id}/upload/${token}/`,
+        context.requestUrl,
+      ).toString(),
+    })
+  }
+
+  if (input?.action === 'setCover') {
+    const src = typeof input.src === 'string' ? input.src.trim() : ''
+    const alt = typeof input.alt === 'string' ? input.alt.trim() : ''
+    const width = typeof input.width === 'number' ? input.width : 0
+    const height = typeof input.height === 'number' ? input.height : 0
+    if (!src || !alt || width <= 0 || height <= 0) {
+      throw new GalleryAdminCommandError('Cover photo is invalid.', 400)
+    }
+
+    const [photos, guests] = await Promise.all([
+      dependencies.data.listGalleryPhotos(context.event.id),
+      dependencies.data.listGuestPhotos(context.event.id),
+    ])
+    const allowed = new Set([
+      ...photos.map((photo) => `${GALLERY_PUBLIC_ORIGIN}/${photo.object_key}`),
+      ...guests
+        .filter(({ status }) => status === 'published')
+        .map((photo) => `${GALLERY_PUBLIC_ORIGIN}/${photo.object_key}`),
+      ...context.event.staticPhotos.map(({ src: photoSrc }) => photoSrc),
+      ...(context.event.flyerSrc ? [context.event.flyerSrc] : []),
+      ...(context.event.coverSrc ? [context.event.coverSrc] : []),
+    ])
+    if (!allowed.has(src)) {
+      throw new GalleryAdminCommandError('Cover photo is not available.', 404)
+    }
+    if (!context.event.title || !context.event.summary) {
+      throw new GalleryAdminCommandError(
+        'Save event details before setting a cover.',
+        409,
+      )
+    }
+    await dependencies.data.saveEventGallery({
+      ...currentEventInput(context.event),
+      cover: { src, width, height, alt: alt.slice(0, 240) },
+    })
+    return ok()
+  }
+
+  if (input?.action === 'uploadAdminPhoto') {
+    const file = input.file
+    if (!(file instanceof File) || !acceptedGalleryImage(file)) {
+      throw new GalleryAdminCommandError(
+        'Choose a JPEG, PNG, WebP, or HEIC photo under 20 MB.',
+        415,
+      )
+    }
+    const optimized = await dependencies.images.optimize(file)
+    const id = dependencies.createId()
+    const objectKey = adminPhotoKey(context.event.id, id)
+    await dependencies.objects.putPublic(objectKey, optimized.buffer, {
+      contentType: 'image/jpeg',
+      cacheControl: 'public, max-age=300',
+    })
+    try {
+      await dependencies.data.insertGalleryPhoto({
+        id,
+        event_slug: context.event.id,
+        object_key: objectKey,
+        original_filename: safeGalleryFilename(file.name),
+        width: optimized.width,
+        height: optimized.height,
+        alt:
+          (typeof input.alt === 'string'
+            ? input.alt.trim().slice(0, 240)
+            : '') || `Photo from ${context.event.title}`,
+        uploader_name: null,
+        source: 'admin',
+      })
+    } catch (error) {
+      await dependencies.objects.deletePublic(objectKey)
+      throw error
+    }
+    return { status: 201, body: { ok: true, id } }
+  }
+
+  if (input?.action === 'updateFlyer') {
+    const file = input.file
+    if (!(file instanceof File) || !acceptedGalleryImage(file)) {
+      throw new GalleryAdminCommandError(
+        'Choose a JPEG, PNG, WebP, or HEIC image under 20 MB.',
+        415,
+      )
+    }
+    if (!context.event.title || !context.event.summary) {
+      throw new GalleryAdminCommandError(
+        'Save event details before replacing the flyer.',
+        409,
+      )
+    }
+    const optimized = await dependencies.images.optimize(file)
+    const objectKey = `events/${context.event.id}/flyer-${dependencies.createId()}.jpg`
+    await dependencies.objects.putPublic(objectKey, optimized.buffer, {
+      contentType: 'image/jpeg',
+      cacheControl: 'public, max-age=300',
+    })
+    const flyer = {
+      object_key: objectKey,
+      width: optimized.width,
+      height: optimized.height,
+      alt: `${context.event.title} flyer`,
+    }
+    try {
+      await dependencies.data.saveEventGallery({
+        ...currentEventInput(context.event),
+        flyer,
+        cover: {
+          src: `${GALLERY_PUBLIC_ORIGIN}/${objectKey}`,
+          width: optimized.width,
+          height: optimized.height,
+          alt: flyer.alt,
+        },
+      })
+    } catch (error) {
+      await dependencies.objects.deletePublic(objectKey)
+      throw error
+    }
+    return { status: 201, body: { ok: true, flyer } }
+  }
+
+  const action = parseGalleryAdminAction(value)
+  if (!action) throw new GalleryAdminCommandError('Invalid action.', 400)
+
+  if (action.action === 'settings') {
+    const existing = await dependencies.data.getSettings(context.event.id)
+    const newPassword = action.password?.trim()
+    if (newPassword && !dependencies.passwords.valid(newPassword)) {
+      throw new GalleryAdminCommandError(
+        'Password must be 8 to 128 characters.',
+        400,
+      )
+    }
+    if (
+      action.uploadsEnabled &&
+      !newPassword &&
+      (!existing?.password_hash || !existing.password_salt)
+    ) {
+      throw new GalleryAdminCommandError(
+        'Set a password before enabling uploads.',
+        400,
+      )
+    }
+    const password = newPassword
+      ? await dependencies.passwords.hash(newPassword)
+      : undefined
+    await dependencies.data.saveSettings(
+      context.event.id,
+      action.uploadsEnabled,
+      password,
+    )
+    return ok()
+  }
+
+  if (
+    action.action === 'hideProfessional' ||
+    action.action === 'restoreProfessional'
+  ) {
+    const available = new Set(
+      context.event.staticPhotos.map(({ filename }) => filename),
+    )
+    if (!available.has(action.filename)) {
+      throw new GalleryAdminCommandError('Professional photo not found.', 404)
+    }
+    if (action.action === 'hideProfessional') {
+      await dependencies.data.hideProfessionalPhoto(
+        context.event.id,
+        action.filename,
+      )
+    } else {
+      await dependencies.data.restoreProfessionalPhoto(
+        context.event.id,
+        action.filename,
+      )
+    }
+    return ok()
+  }
+
+  if (
+    action.action !== 'approveGuest' &&
+    action.action !== 'rejectGuest' &&
+    action.action !== 'removeGuest'
+  ) {
+    throw new GalleryAdminCommandError('Invalid action.', 400)
+  }
+  return moderateGuestPhoto(context, action, dependencies)
+}

--- a/src/lib/gallery-admin-commands.ts
+++ b/src/lib/gallery-admin-commands.ts
@@ -1,7 +1,3 @@
-import {
-  parseGalleryAdminAction,
-  type GalleryAdminAction,
-} from './gallery-admin'
 import { hashGalleryPassword, validGalleryPassword } from './gallery-auth'
 import {
   GALLERY_PUBLIC_ORIGIN,
@@ -37,6 +33,10 @@ import {
 type GalleryAdminObjectBody = Parameters<R2Bucket['put']>[1]
 
 type GalleryAdminPassword = { salt: string; hash: string }
+
+type GuestModerationAction =
+  | { action: 'approveGuest'; photoId: string; alt?: string }
+  | { action: 'rejectGuest' | 'removeGuest'; photoId: string }
 
 export type GalleryAdminEventContext = {
   id: string
@@ -242,7 +242,7 @@ function currentEventInput(
 
 async function moderateGuestPhoto(
   context: GalleryAdminCommandContext,
-  action: Extract<GalleryAdminAction, { photoId: string }>,
+  action: GuestModerationAction,
   dependencies: GalleryAdminCommandDependencies,
 ): Promise<GalleryAdminCommandResult> {
   const photo = await dependencies.data.getGuestPhoto(action.photoId)
@@ -363,11 +363,9 @@ export async function executeGalleryAdminCommand(
   dependencies: GalleryAdminCommandDependencies,
 ): Promise<GalleryAdminCommandResult> {
   const input =
-    value && typeof value === 'object'
-      ? (value as Record<string, unknown>)
-      : undefined
+    value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
 
-  if (input?.action === 'updateEvent') {
+  if (input.action === 'updateEvent') {
     const title = typeof input.title === 'string' ? input.title.trim() : ''
     const summary =
       typeof input.summary === 'string' ? input.summary.trim() : ''
@@ -405,7 +403,7 @@ export async function executeGalleryAdminCommand(
     return ok()
   }
 
-  if (input?.action === 'createInvite') {
+  if (input.action === 'createInvite') {
     const guestName =
       typeof input.guestName === 'string' ? input.guestName.trim() : ''
     if (!guestName) {
@@ -427,7 +425,7 @@ export async function executeGalleryAdminCommand(
     })
   }
 
-  if (input?.action === 'setCover') {
+  if (input.action === 'setCover') {
     const src = typeof input.src === 'string' ? input.src.trim() : ''
     const alt = typeof input.alt === 'string' ? input.alt.trim() : ''
     const width = typeof input.width === 'number' ? input.width : 0
@@ -465,8 +463,8 @@ export async function executeGalleryAdminCommand(
     return ok()
   }
 
-  if (input?.action === 'uploadAdminPhoto') {
-    const file = input.file
+  if (input.action === 'uploadAdminPhoto') {
+    const { file } = input
     if (!(file instanceof File) || !acceptedGalleryImage(file)) {
       throw new GalleryAdminCommandError(
         'Choose a JPEG, PNG, WebP, or HEIC photo under 20 MB.',
@@ -502,8 +500,8 @@ export async function executeGalleryAdminCommand(
     return { status: 201, body: { ok: true, id } }
   }
 
-  if (input?.action === 'updateFlyer') {
-    const file = input.file
+  if (input.action === 'updateFlyer') {
+    const { file } = input
     if (!(file instanceof File) || !acceptedGalleryImage(file)) {
       throw new GalleryAdminCommandError(
         'Choose a JPEG, PNG, WebP, or HEIC image under 20 MB.',
@@ -546,12 +544,16 @@ export async function executeGalleryAdminCommand(
     return { status: 201, body: { ok: true, flyer } }
   }
 
-  const action = parseGalleryAdminAction(value)
-  if (!action) throw new GalleryAdminCommandError('Invalid action.', 400)
-
-  if (action.action === 'settings') {
+  if (input.action === 'settings') {
+    if (
+      typeof input.uploadsEnabled !== 'boolean' ||
+      (input.password !== undefined && typeof input.password !== 'string')
+    ) {
+      throw new GalleryAdminCommandError('Invalid action.', 400)
+    }
     const existing = await dependencies.data.getSettings(context.event.id)
-    const newPassword = action.password?.trim()
+    const newPassword =
+      typeof input.password === 'string' ? input.password.trim() : undefined
     if (newPassword && !dependencies.passwords.valid(newPassword)) {
       throw new GalleryAdminCommandError(
         'Password must be 8 to 128 characters.',
@@ -559,7 +561,7 @@ export async function executeGalleryAdminCommand(
       )
     }
     if (
-      action.uploadsEnabled &&
+      input.uploadsEnabled &&
       !newPassword &&
       (!existing?.password_hash || !existing.password_salt)
     ) {
@@ -573,42 +575,55 @@ export async function executeGalleryAdminCommand(
       : undefined
     await dependencies.data.saveSettings(
       context.event.id,
-      action.uploadsEnabled,
+      input.uploadsEnabled,
       password,
     )
     return ok()
   }
 
   if (
-    action.action === 'hideProfessional' ||
-    action.action === 'restoreProfessional'
+    (input.action === 'hideProfessional' ||
+      input.action === 'restoreProfessional') &&
+    typeof input.filename === 'string'
   ) {
     const available = new Set(
       context.event.staticPhotos.map(({ filename }) => filename),
     )
-    if (!available.has(action.filename)) {
+    if (!available.has(input.filename)) {
       throw new GalleryAdminCommandError('Professional photo not found.', 404)
     }
-    if (action.action === 'hideProfessional') {
+    if (input.action === 'hideProfessional') {
       await dependencies.data.hideProfessionalPhoto(
         context.event.id,
-        action.filename,
+        input.filename,
       )
     } else {
       await dependencies.data.restoreProfessionalPhoto(
         context.event.id,
-        action.filename,
+        input.filename,
       )
     }
     return ok()
   }
 
+  let guestAction: GuestModerationAction
   if (
-    action.action !== 'approveGuest' &&
-    action.action !== 'rejectGuest' &&
-    action.action !== 'removeGuest'
+    input.action === 'approveGuest' &&
+    typeof input.photoId === 'string' &&
+    (input.alt === undefined || typeof input.alt === 'string')
   ) {
+    guestAction = {
+      action: input.action,
+      photoId: input.photoId,
+      alt: typeof input.alt === 'string' ? input.alt : undefined,
+    }
+  } else if (
+    (input.action === 'rejectGuest' || input.action === 'removeGuest') &&
+    typeof input.photoId === 'string'
+  ) {
+    guestAction = { action: input.action, photoId: input.photoId }
+  } else {
     throw new GalleryAdminCommandError('Invalid action.', 400)
   }
-  return moderateGuestPhoto(context, action, dependencies)
+  return moderateGuestPhoto(context, guestAction, dependencies)
 }

--- a/src/lib/gallery-admin.test.ts
+++ b/src/lib/gallery-admin.test.ts
@@ -2,10 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { exportJWK, generateKeyPair, SignJWT } from 'jose'
 
-import {
-  galleryAdminAuthorized,
-  parseGalleryAdminAction,
-} from './gallery-admin'
+import { galleryAdminAuthorized } from './gallery-admin'
 
 test('requires a signed Access token outside local development', async () => {
   const production = new Request('https://ayoubabed.xyz/admin/galleries', {
@@ -67,30 +64,4 @@ test('accepts a valid Access JWT for the configured admin', async () => {
   } finally {
     globalThis.fetch = originalFetch
   }
-})
-
-test('parses only supported admin actions', () => {
-  assert.deepEqual(
-    parseGalleryAdminAction({
-      action: 'settings',
-      uploadsEnabled: true,
-      password: 'event-password',
-    }),
-    {
-      action: 'settings',
-      uploadsEnabled: true,
-      password: 'event-password',
-    },
-  )
-  assert.deepEqual(
-    parseGalleryAdminAction({
-      action: 'hideProfessional',
-      filename: 'photo.jpg',
-    }),
-    { action: 'hideProfessional', filename: 'photo.jpg' },
-  )
-  assert.equal(
-    parseGalleryAdminAction({ action: 'deleteEverything' }),
-    undefined,
-  )
 })

--- a/src/lib/gallery-admin.ts
+++ b/src/lib/gallery-admin.ts
@@ -2,26 +2,6 @@ import { createRemoteJWKSet, jwtVerify } from 'jose'
 
 const accessKeySets = new Map<string, ReturnType<typeof createRemoteJWKSet>>()
 
-export type GalleryAdminAction =
-  | {
-      action: 'settings'
-      uploadsEnabled: boolean
-      password?: string
-    }
-  | {
-      action: 'approveGuest'
-      photoId: string
-      alt?: string
-    }
-  | {
-      action: 'rejectGuest' | 'removeGuest'
-      photoId: string
-    }
-  | {
-      action: 'hideProfessional' | 'restoreProfessional'
-      filename: string
-    }
-
 export async function galleryAdminAuthorized(
   request: Request,
   adminEmail: string,
@@ -54,51 +34,5 @@ export async function galleryAdminAuthorized(
     )
   } catch {
     return false
-  }
-}
-
-export function parseGalleryAdminAction(
-  value: unknown,
-): GalleryAdminAction | undefined {
-  if (!value || typeof value !== 'object' || !('action' in value)) return
-  const input = value as Record<string, unknown>
-
-  if (
-    input.action === 'settings' &&
-    typeof input.uploadsEnabled === 'boolean' &&
-    (input.password === undefined || typeof input.password === 'string')
-  ) {
-    const password =
-      typeof input.password === 'string' ? input.password : undefined
-    return {
-      action: 'settings',
-      uploadsEnabled: input.uploadsEnabled,
-      password,
-    }
-  }
-  if (
-    input.action === 'approveGuest' &&
-    typeof input.photoId === 'string' &&
-    (input.alt === undefined || typeof input.alt === 'string')
-  ) {
-    const alt = typeof input.alt === 'string' ? input.alt : undefined
-    return {
-      action: input.action,
-      photoId: input.photoId,
-      alt,
-    }
-  }
-  if (
-    (input.action === 'rejectGuest' || input.action === 'removeGuest') &&
-    typeof input.photoId === 'string'
-  ) {
-    return { action: input.action, photoId: input.photoId }
-  }
-  if (
-    (input.action === 'hideProfessional' ||
-      input.action === 'restoreProfessional') &&
-    typeof input.filename === 'string'
-  ) {
-    return { action: input.action, filename: input.filename }
   }
 }

--- a/src/pages/api/admin/galleries/[slug].ts
+++ b/src/pages/api/admin/galleries/[slug].ts
@@ -2,38 +2,24 @@ import type { APIRoute } from 'astro'
 import { getEntry } from 'astro:content'
 import { env } from 'cloudflare:workers'
 
+import { galleryAdminAuthorized } from '@/lib/gallery-admin'
 import {
-  galleryAdminAuthorized,
-  parseGalleryAdminAction,
-} from '@/lib/gallery-admin'
-import { hashGalleryPassword, validGalleryPassword } from '@/lib/gallery-auth'
+  createGalleryAdminCommandDependencies,
+  executeGalleryAdminCommand,
+  GalleryAdminCommandError,
+  type GalleryAdminEventContext,
+} from '@/lib/gallery-admin-commands'
 import {
-  adminPhotoKey,
-  createGalleryInvite,
-  deleteGuestPhoto,
   getEventGallery,
   getGallerySettings,
   getGuestPhoto,
-  galleryStatus,
-  hideProfessionalPhoto,
-  insertGalleryPhoto,
   listGalleryInvites,
   listGalleryPhotos,
   listGuestPhotos,
   listHiddenPhotos,
   publicEventCover,
   publicEventFlyer,
-  publishGuestPhoto,
-  publishedGuestKey,
-  restoreProfessionalPhoto,
-  saveEventGallery,
-  saveGallerySettings,
 } from '@/lib/gallery-data'
-import {
-  acceptedGalleryImage,
-  optimizedGalleryImage,
-  safeGalleryFilename,
-} from '@/lib/gallery-upload'
 
 export const prerender = false
 
@@ -53,9 +39,29 @@ async function eventGallery(eventSlug: string | undefined) {
     : undefined
 }
 
-function eventSnapshot(event: Awaited<ReturnType<typeof eventGallery>>) {
-  if (!event) return
+function commandEvent(
+  event: NonNullable<Awaited<ReturnType<typeof eventGallery>>>,
+): GalleryAdminEventContext {
+  const staticPhotos =
+    event.staticEvent?.data.gallery
+      .filter(
+        (
+          image,
+        ): image is Extract<
+          (typeof event.staticEvent.data.gallery)[number],
+          { filename: string }
+        > => 'filename' in image,
+      )
+      .map(({ src, filename }) => ({ src, filename })) ?? []
+  const flyer = event.dynamicEvent
+    ? publicEventFlyer(event.dynamicEvent)
+    : undefined
+  const cover = event.dynamicEvent
+    ? publicEventCover(event.dynamicEvent)
+    : undefined
+
   return {
+    id: event.id,
     title: event.dynamicEvent?.title ?? event.staticEvent?.data.title ?? '',
     summary:
       event.dynamicEvent?.summary ??
@@ -80,6 +86,9 @@ function eventSnapshot(event: Awaited<ReturnType<typeof eventGallery>>) {
       null,
     comingSoon: Boolean(event.dynamicEvent?.coming_soon),
     status: event.dynamicEvent?.status ?? 'published',
+    flyerSrc: flyer?.src,
+    coverSrc: cover?.src,
+    staticPhotos,
   }
 }
 
@@ -142,6 +151,7 @@ export const POST: APIRoute = async ({ params, request }) => {
   const event = await eventGallery(params.slug)
   if (!event) return json({ error: 'Gallery not found.' }, 404)
 
+  let command: unknown
   const contentType = request.headers.get('content-type') ?? ''
   if (contentType.includes('multipart/form-data')) {
     let formData: FormData
@@ -151,346 +161,46 @@ export const POST: APIRoute = async ({ params, request }) => {
       return json({ error: 'Invalid form submission.' }, 400)
     }
     const action = formData.get('action')
-
-    if (action === 'uploadAdminPhoto') {
-      const file = formData.get('photo')
-      if (!(file instanceof File) || !acceptedGalleryImage(file)) {
-        return json(
-          { error: 'Choose a JPEG, PNG, WebP, or HEIC photo under 20 MB.' },
-          415,
-        )
-      }
-      const optimized = await optimizedGalleryImage(file, env.IMAGES)
-      const id = crypto.randomUUID()
-      const objectKey = adminPhotoKey(event.id, id)
-      await env.GALLERY_PUBLIC.put(objectKey, optimized.buffer, {
-        httpMetadata: {
-          contentType: 'image/jpeg',
-          cacheControl: 'public, max-age=300',
-        },
-      })
-      try {
-        await insertGalleryPhoto(env.GALLERY_DB, {
-          id,
-          event_slug: event.id,
-          object_key: objectKey,
-          original_filename: safeGalleryFilename(file.name),
-          width: optimized.width,
-          height: optimized.height,
-          alt:
-            (typeof formData.get('alt') === 'string'
-              ? formData.get('alt')?.toString().trim().slice(0, 240)
-              : '') ||
-            `Photo from ${event.dynamicEvent?.title ?? event.staticEvent?.data.title}`,
-          uploader_name: null,
-          source: 'admin',
-        })
-      } catch (error) {
-        await env.GALLERY_PUBLIC.delete(objectKey)
-        throw error
-      }
-      return json({ ok: true, id }, 201)
+    command = {
+      action,
+      file:
+        action === 'uploadAdminPhoto'
+          ? formData.get('photo')
+          : formData.get('flyer'),
+      alt: formData.get('alt'),
     }
-
-    if (action === 'updateFlyer') {
-      const file = formData.get('flyer')
-      if (!(file instanceof File) || !acceptedGalleryImage(file)) {
-        return json(
-          { error: 'Choose a JPEG, PNG, WebP, or HEIC image under 20 MB.' },
-          415,
-        )
-      }
-      const details = eventSnapshot(event)
-      if (!details.title || !details.summary) {
-        return json(
-          { error: 'Save event details before replacing the flyer.' },
-          409,
-        )
-      }
-      const optimized = await optimizedGalleryImage(file, env.IMAGES)
-      const objectKey = `events/${event.id}/flyer-${crypto.randomUUID()}.jpg`
-      await env.GALLERY_PUBLIC.put(objectKey, optimized.buffer, {
-        httpMetadata: {
-          contentType: 'image/jpeg',
-          cacheControl: 'public, max-age=300',
-        },
-      })
-      const flyer = {
-        object_key: objectKey,
-        width: optimized.width,
-        height: optimized.height,
-        alt: `${details.title} flyer`,
-      }
-      await saveEventGallery(env.GALLERY_DB, {
-        event_slug: event.id,
-        title: details.title,
-        summary: details.summary,
-        category: details.category,
-        event_date: details.eventDate,
-        event_time: details.eventTime,
-        event_venue: details.eventVenue,
-        coming_soon: details.comingSoon,
-        status: details.status,
-        flyer,
-        cover: {
-          src: `https://photos.ayoubabed.xyz/${objectKey}`,
-          width: optimized.width,
-          height: optimized.height,
-          alt: flyer.alt,
-        },
-      })
-      return json({ ok: true, flyer }, 201)
-    }
-
-    return json({ error: 'Invalid action.' }, 400)
-  }
-
-  const contentLength = Number(request.headers.get('content-length') ?? 0)
-  if (contentLength > 4096) {
-    return json({ error: 'Request is too large.' }, 413)
-  }
-  let value: unknown
-  try {
-    const text = await request.text()
-    if (new TextEncoder().encode(text).byteLength > 4096) {
+  } else {
+    const contentLength = Number(request.headers.get('content-length') ?? 0)
+    if (contentLength > 4096) {
       return json({ error: 'Request is too large.' }, 413)
     }
-    value = JSON.parse(text)
-  } catch {
-    return json({ error: 'Invalid JSON.' }, 400)
-  }
-  const action = parseGalleryAdminAction(value)
-  const input =
-    value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
-  if (
-    !action &&
-    input.action !== 'updateEvent' &&
-    input.action !== 'createInvite' &&
-    input.action !== 'setCover'
-  ) {
-    return json({ error: 'Invalid action.' }, 400)
-  }
-
-  if (input.action === 'updateEvent') {
-    const title = typeof input.title === 'string' ? input.title.trim() : ''
-    const summary =
-      typeof input.summary === 'string' ? input.summary.trim() : ''
-    if (!title || !summary) {
-      return json({ error: 'Name and about information are required.' }, 400)
-    }
-    await saveEventGallery(env.GALLERY_DB, {
-      event_slug: event.id,
-      title,
-      event_date:
-        typeof input.eventDate === 'string' && input.eventDate
-          ? input.eventDate
-          : null,
-      event_time:
-        typeof input.eventTime === 'string' && input.eventTime
-          ? input.eventTime
-          : null,
-      event_venue:
-        typeof input.eventVenue === 'string' && input.eventVenue
-          ? input.eventVenue
-          : null,
-      summary,
-      category:
-        typeof input.category === 'string' && input.category.trim()
-          ? input.category.trim()
-          : 'Event Photography',
-      coming_soon: Boolean(input.comingSoon),
-      status:
-        galleryStatus(input.visibilityStatus) ??
-        (input.comingSoon ? 'coming_soon' : 'published'),
-    })
-    return json({ ok: true })
-  }
-
-  if (input.action === 'createInvite') {
-    const guestName =
-      typeof input.guestName === 'string' ? input.guestName.trim() : ''
-    if (!guestName) return json({ error: 'Guest name is required.' }, 400)
-    const token = crypto.randomUUID()
-    await createGalleryInvite(env.GALLERY_DB, {
-      token,
-      event_slug: event.id,
-      guest_name: guestName.slice(0, 120),
-    })
-    return json({
-      ok: true,
-      token,
-      url: new URL(
-        `/galleries/${event.id}/upload/${token}/`,
-        request.url,
-      ).toString(),
-    })
-  }
-
-  if (input.action === 'setCover') {
-    const src = typeof input.src === 'string' ? input.src.trim() : ''
-    const alt = typeof input.alt === 'string' ? input.alt.trim() : ''
-    const width = typeof input.width === 'number' ? input.width : 0
-    const height = typeof input.height === 'number' ? input.height : 0
-    if (!src || !alt || width <= 0 || height <= 0) {
-      return json({ error: 'Cover photo is invalid.' }, 400)
-    }
-
-    const [photos, guests] = await Promise.all([
-      listGalleryPhotos(env.GALLERY_DB, event.id),
-      listGuestPhotos(env.GALLERY_DB, event.id),
-    ])
-    const staticImages =
-      event.staticEvent?.data.gallery.filter(
-        (
-          image,
-        ): image is Extract<
-          (typeof event.staticEvent.data.gallery)[number],
-          { filename: string }
-        > => 'filename' in image,
-      ) ?? []
-    const flyer = event.dynamicEvent
-      ? publicEventFlyer(event.dynamicEvent)
-      : undefined
-    const currentCover = event.dynamicEvent
-      ? publicEventCover(event.dynamicEvent)
-      : undefined
-    const allowed = new Set([
-      ...photos.map(
-        (photo) => `https://photos.ayoubabed.xyz/${photo.object_key}`,
-      ),
-      ...guests
-        .filter(({ status }) => status === 'published')
-        .map((photo) => `https://photos.ayoubabed.xyz/${photo.object_key}`),
-      ...staticImages.map(({ src }) => src),
-      ...(flyer ? [flyer.src] : []),
-      ...(currentCover ? [currentCover.src] : []),
-    ])
-    if (!allowed.has(src))
-      return json({ error: 'Cover photo is not available.' }, 404)
-
-    const details = eventSnapshot(event)
-    if (!details.title || !details.summary) {
-      return json({ error: 'Save event details before setting a cover.' }, 409)
-    }
-    const cover = { src, width, height, alt: alt.slice(0, 240) }
-    await saveEventGallery(env.GALLERY_DB, {
-      event_slug: event.id,
-      title: details.title,
-      summary: details.summary,
-      category: details.category,
-      event_date: details.eventDate,
-      event_time: details.eventTime,
-      event_venue: details.eventVenue,
-      coming_soon: details.comingSoon,
-      status: details.status,
-      cover,
-    })
-    return json({ ok: true })
-  }
-
-  if (action?.action === 'settings') {
-    const existing = await getGallerySettings(env.GALLERY_DB, event.id)
-    const newPassword = action.password?.trim()
-    if (newPassword && !validGalleryPassword(newPassword)) {
-      return json({ error: 'Password must be 8 to 128 characters.' }, 400)
-    }
-    if (
-      action.uploadsEnabled &&
-      !newPassword &&
-      (!existing?.password_hash || !existing.password_salt)
-    ) {
-      return json({ error: 'Set a password before enabling uploads.' }, 400)
-    }
-    const password = newPassword
-      ? await hashGalleryPassword(newPassword)
-      : undefined
-    await saveGallerySettings(
-      env.GALLERY_DB,
-      event.id,
-      action.uploadsEnabled,
-      password,
-    )
-    return json({ ok: true })
-  }
-
-  if (!action) return json({ error: 'Invalid action.' }, 400)
-
-  if (
-    action.action === 'approveGuest' ||
-    action.action === 'rejectGuest' ||
-    action.action === 'removeGuest'
-  ) {
-    const photo = await getGuestPhoto(env.GALLERY_DB, action.photoId)
-    if (!photo || photo.event_slug !== event.id) {
-      return json({ error: 'Photo not found.' }, 404)
-    }
-
-    if (action.action === 'approveGuest') {
-      if (photo.status === 'published') return json({ ok: true })
-      const publicKey = publishedGuestKey(event.id, photo.id)
-      const pending = await env.GALLERY_PENDING.get(photo.object_key)
-      if (pending) {
-        await env.GALLERY_PUBLIC.put(publicKey, pending.body, {
-          httpMetadata: {
-            contentType: 'image/jpeg',
-            cacheControl: 'public, max-age=300',
-          },
-        })
-      } else if (!(await env.GALLERY_PUBLIC.head(publicKey))) {
-        return json({ error: 'Pending image is missing.' }, 409)
+    try {
+      const text = await request.text()
+      if (new TextEncoder().encode(text).byteLength > 4096) {
+        return json({ error: 'Request is too large.' }, 413)
       }
-      const alt = action.alt?.trim().slice(0, 240) || photo.alt
-      await publishGuestPhoto(env.GALLERY_DB, photo.id, publicKey, alt)
-      await env.GALLERY_PENDING.delete(photo.object_key)
-    } else {
-      if (action.action === 'rejectGuest' && photo.status !== 'pending') {
-        return json({ error: 'Published photos must be removed instead.' }, 409)
-      }
-      const bucket =
-        photo.status === 'pending' ? env.GALLERY_PENDING : env.GALLERY_PUBLIC
-      await bucket.delete(photo.object_key)
-      await deleteGuestPhoto(env.GALLERY_DB, photo.id)
+      command = JSON.parse(text)
+    } catch {
+      return json({ error: 'Invalid JSON.' }, 400)
     }
+  }
 
-    console.log(
-      JSON.stringify({
-        message: 'gallery guest moderation completed',
-        eventSlug: event.id,
-        action: action.action,
-        photoId: photo.id,
+  try {
+    const result = await executeGalleryAdminCommand(
+      { event: commandEvent(event), requestUrl: request.url },
+      command,
+      createGalleryAdminCommandDependencies({
+        database: env.GALLERY_DB,
+        pendingBucket: env.GALLERY_PENDING,
+        publicBucket: env.GALLERY_PUBLIC,
+        images: env.IMAGES,
       }),
     )
-    return json({ ok: true })
+    return json(result.body, result.status)
+  } catch (error) {
+    if (error instanceof GalleryAdminCommandError) {
+      return json({ error: error.message }, error.status)
+    }
+    throw error
   }
-
-  if (
-    action.action !== 'hideProfessional' &&
-    action.action !== 'restoreProfessional'
-  ) {
-    return json({ error: 'Invalid action.' }, 400)
-  }
-
-  if (!event.staticEvent) {
-    return json({ error: 'Professional photo not found.' }, 404)
-  }
-
-  const inlineImages = event.staticEvent.data.gallery.filter(
-    (
-      image,
-    ): image is Extract<
-      (typeof event.staticEvent.data.gallery)[number],
-      { filename: string }
-    > => 'filename' in image,
-  )
-  const available = new Set(inlineImages.map(({ filename }) => filename))
-  if (!available.has(action.filename)) {
-    return json({ error: 'Professional photo not found.' }, 404)
-  }
-
-  if (action.action === 'hideProfessional') {
-    await hideProfessionalPhoto(env.GALLERY_DB, event.id, action.filename)
-  } else {
-    await restoreProfessionalPhoto(env.GALLERY_DB, event.id, action.filename)
-  }
-  return json({ ok: true })
 }


### PR DESCRIPTION
## What changed

- move gallery administration workflows out of the Astro route and behind one command module
- keep validation, D1/R2 ordering, rollback, and retry cleanup together
- remove the duplicate admin-action parser
- replace repeated test setup with compact fixtures while retaining storage-failure coverage
- preserve the current gallery-read tests added on `master`

## Why

The route previously owned command parsing and multi-system mutation recipes, which made the risky failure paths difficult to test through one stable interface. The follow-up simplification removes 632 lines of duplicated parser and test setup from the first implementation.

## Impact

Admin behavior and response shapes remain unchanged. Failed D1/R2 transitions retain or restore objects so retries remain safe.

## Validation

- `npm run verify`
- 31 gallery tests passed
- 13 face/client tests passed
- Astro typecheck passed
- production build passed
