### PR TITLE
Update wedding pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,12 +564,12 @@ This file defines:
 - Typography
 - Tailwind theme values
 - Base styles
-- MDX case-study styles under `.portfolio-prose`
+- MDX case-study styles under `.typeset-portfolio`
 - Reduced-motion behavior
 
 The site follows the visitor's operating-system light or dark preference.
 
-Portfolio heading and paragraph spacing is controlled by `.portfolio-prose`,
+Portfolio heading and paragraph spacing is controlled by `.typeset-portfolio`,
 not by the number of blank lines in an MDX file. Markdown blank lines separate
 content in the source, but they do not create extra visual space in the rendered
 HTML. Adjust the shared prose rules when vertical rhythm needs to change so

--- a/docs/tampa-wedding-video-pricing-research.md
+++ b/docs/tampa-wedding-video-pricing-research.md
@@ -1,0 +1,48 @@
+# Tampa wedding video pricing research
+
+Researched July 10, 2026. Published local packages are comparison points, not a rate card; confirm each vendor's current availability and scope before quoting them.
+
+## Local published reference points
+
+| Vendor                                                                                                       | Published package / scope                                                                                                                            |             Price |
+| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------: |
+| [Digital Video Production FL](https://dvpfl.com/packages/)                                                   | Ceremony, up to 1 hour with editing; extra ceremony camera costs $200                                                                                |              $499 |
+| [Digital Video Production FL](https://dvpfl.com/packages/)                                                   | Four-hour documentary/full-feature coverage of major moments in their entirety                                                                       |              $999 |
+| [Berlew Weddings](https://berlewweddings.com/)                                                               | Full ceremony, multiple angles, two videographers                                                                                                    |              $600 |
+| [Tampa Film Company](https://www.tampafilmco.com/packages)                                                   | One videographer, up to one hour, full-length multicamera ceremony, 4K and lapel audio                                                               |            $1,000 |
+| [Tampa Bay Cameraman](https://www.tbcameraman.com/services/weddings/)                                        | Ceremony-only: 2 videographers, 3 cameras, full multicam ceremony cut (up to 30 minutes), one revision, digital download                             |            $1,000 |
+| [Tampa Bay Cameraman](https://www.tbcameraman.com/services/weddings/)                                        | 6 hours, 2 videographers/3 ceremony cameras, full ceremony and up-to-10-minute highlight                                                             |            $1,750 |
+| [Dream Reel Video](https://dreamreelvideo.com/videographer-pricing-packages-tampa-clearwater-st-petersburg/) | 6 hours, one cinematographer, 2 cameras, edited full ceremony/speeches/dances/toasts plus highlight and download                                     |            $2,500 |
+| [Event Heroes of Tampa Bay](https://www.eventheroesoftampabay.com/Videography-Pricing)                       | 4 hours and a 3-5-minute highlight                                                                                                                   |            $1,500 |
+| [MARGOz Production](https://margozproduction.com/pricing)                                                    | 5 hours, one videographer (video-only option); package describes a 2-3-minute highlight                                                              |            $2,000 |
+| [MARGOz Production](https://margozproduction.com/pricing)                                                    | 12 hours, two videographers; video-only option is $5,000. The combined package includes a 5-7-minute highlight, full ceremony film, and raw footage. | $5,000 video-only |
+
+## What the comparison says
+
+- A $540 combined photo/video job with a long edited film was far below the published local references above. Even the lowest ceremony-only multicamera example found is $1,000.
+- "Raw" or "documentary" should be specified precisely. A continuous, camera-original file is different from a synced multi-camera ceremony cut, which still needs ingesting, syncing, audio checks, export, upload, and storage.
+- Multi-camera coverage is a production requirement, not a free deliverable: it needs extra bodies or locked-off cameras, redundant audio, media, batteries, and setup/strike time.
+
+## Practical starter structure to test
+
+Keep the public menu small and use a written custom quote for anything beyond it:
+
+1. **Ceremony Documentation, starting at $750-950:** one videographer, two locked camera angles, dedicated audio, up to 60-minute ceremony, continuous files delivered digitally. No highlight edit. Use the low end only for a very limited, nearby ceremony.
+2. **Wedding-Day Documentation, starting at $1,200-1,400:** one videographer, up to 4 hours, agreed key blocks (for example ceremony, speeches, and dances), continuous files delivered digitally. This is not a guarantee of uninterrupted coverage while one operator changes batteries, cards, position, or manages audio.
+3. **Add-ons:** extra coverage hour $200-250; second videographer $100-150/hour; edited multicamera ceremony cut $350-500; a photo/event-gallery add-on should be separately priced based on shooting hours and the number of edited images.
+
+These are deliberately simple positioning recommendations inferred from the Tampa examples, rather than claims of a market average. They make the lower-priced option genuinely low-edit while reserving editing and additional labor for paid add-ons.
+
+## Quote and contract guardrails
+
+- State the exact coverage window, camera count, whether an operator stays with every camera, which events are covered, and the delivery method/file retention period.
+- Say **"continuous documentation, lightly trimmed only for starts/stops or technical interruptions"** if that is what is being sold. Do not call it "full wedding" unless every agreed block is covered.
+- Include a meal/break, travel/parking, overtime, deposit, cancellation, music/licensing, venue restrictions, and a limitation that no live-event recording can guarantee every moment. Get the coordinator timeline and confirm where cameras/audio may be placed.
+- For a one-person shoot, do not promise two actively operated angles. Offer two locked angles, or sell a second videographer. Do not bundle event photography into a solo video booking unless the client accepts a narrow photo scope; otherwise use a second shooter.
+
+## Florida operating basics to verify
+
+- If operating under a name other than the owner's legal name or an entity's legal name, Florida says a fictitious-name/DBA registration is required before conducting business. The official filing instructions also say the name must be advertised once in the county of principal business (the applicant certifies this; proof is not filed). [Florida Division of Corporations](https://dos.fl.gov/sunbiz/start-business/efile/fl-fictitious-name-registration/)
+- Florida Revenue says a business selling taxable goods or services must register as a sales-and-use-tax dealer before conducting business. [Florida DOR registration](https://floridarevenue.com/taxes/eservices/Pages/registration.aspx)
+- For video production/editing, Florida DOR's published technical assistance advisement says an internet/file-transfer/e-mail delivery is not subject to sales tax, while delivery on a hard drive, CD, flash drive, or DVD is taxable. Treat this as a useful rule of thumb, not individualized tax advice; confirm the exact invoice/delivery setup with DOR or a CPA. [TAA 11A-002](https://floridarevenue.com/TaxLaw/Documents/TAA%2011A-002.pdf)
+- The current state general sales-tax rate is 6%, with county discretionary surtax potentially applying to taxable sales. [Florida DOR overview](https://floridarevenue.com/Forms_library/current/gt800013.pdf)

--- a/src/content/portfolio/PROJECT_TEMPLATE.mdx.example
+++ b/src/content/portfolio/PROJECT_TEMPLATE.mdx.example
@@ -58,6 +58,6 @@ Write the project story here using normal Markdown. The filename becomes the URL
 You can add paragraphs, lists, links, and additional headings. Delete the body
 entirely if the project does not have a written case study yet.
 
-Heading spacing is controlled globally by `.portfolio-prose` in `src/styles.css`.
+Heading spacing is controlled globally by `.typeset-portfolio` in `src/typeset.css`.
 Keep normal Markdown blank lines for readability; do not add extra blank lines
 to create visual spacing.

--- a/src/pages/portfolio/[slug].astro
+++ b/src/pages/portfolio/[slug].astro
@@ -262,7 +262,7 @@ const galleryHeading =
       {
         hasBody && (
           <section
-            class="portfolio-prose mx-auto max-w-4xl py-8 sm:py-10"
+            class="typeset typeset-portfolio mx-auto max-w-4xl py-8 sm:py-10"
             data-reveal="up"
           >
             <Content />

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -198,6 +198,13 @@ const servicePackages = [
     detail:
       'Clean event sound plus a simple full lecture or program recording delivered as a file.',
   },
+  {
+    name: 'Wedding documentation',
+    price: 'From $850',
+    label: 'Ceremony',
+    detail:
+      'Up to two hours of ceremony coverage with two locked camera angles, dedicated audio, and a full-length digital delivery.',
+  },
 ]
 
 const mediaAddOns = [
@@ -217,6 +224,36 @@ const mediaAddOns = [
     detail: 'A finished short video built from event coverage or interviews.',
   },
   {
+    name: 'Wedding photography + gallery',
+    price: 'From $650',
+    detail:
+      'Photography coverage and a shareable gallery. Full photo and video coverage requires a second shooter.',
+  },
+  {
+    name: 'Wedding highlight film',
+    price: 'From $750',
+    detail:
+      'A finished 3-5 minute wedding story built from documentary coverage.',
+  },
+  {
+    name: 'Extended wedding film',
+    price: 'From $1,250',
+    detail:
+      'A longer edited wedding film for couples who want more than documentary coverage.',
+  },
+  {
+    name: 'Original camera files',
+    price: '$350',
+    detail:
+      'Original camera files delivered digitally after the final project is complete.',
+  },
+  {
+    name: 'Second videographer',
+    price: '$600',
+    detail:
+      'Recommended when a wedding needs active coverage from more than one angle.',
+  },
+  {
     name: 'YouTube upload prep',
     price: '$100-$250',
     detail:
@@ -232,8 +269,8 @@ const starterLimits = [
   },
   {
     label: 'Extra recording time',
-    value: '$100-$150/hr',
-    detail: 'For longer interviews, podcasts, lectures, or event coverage.',
+    value: '$225/hr',
+    detail: 'For wedding coverage beyond the agreed package window.',
   },
   {
     label: 'Extra camera',

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
+@import './typeset.css';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -151,40 +152,6 @@
     opacity: 1;
     transform: translate3d(0, 0, 0);
     will-change: auto;
-  }
-
-  .portfolio-prose {
-    @apply text-muted-foreground max-w-4xl leading-7;
-  }
-
-  .portfolio-prose h2 {
-    @apply font-heading text-foreground mt-10 mb-4 text-2xl font-bold;
-  }
-
-  .portfolio-prose h2:first-child {
-    @apply mt-0;
-  }
-
-  .portfolio-prose h3 {
-    @apply font-heading text-foreground mt-8 mb-3 text-xl font-bold;
-  }
-
-  .portfolio-prose p + p,
-  .portfolio-prose p + ul,
-  .portfolio-prose ul + p {
-    @apply mt-4;
-  }
-
-  .portfolio-prose ul {
-    @apply list-disc pl-6;
-  }
-
-  .portfolio-prose li + li {
-    @apply mt-2;
-  }
-
-  .portfolio-prose a {
-    @apply text-foreground hover:text-primary focus-visible:ring-ring rounded-sm font-semibold underline decoration-dotted underline-offset-4 focus-visible:ring-2 focus-visible:outline-none;
   }
 
   .services-reel-track {

--- a/src/typeset.css
+++ b/src/typeset.css
@@ -1,0 +1,331 @@
+@layer components {
+  .typeset {
+    --typeset-font-body: inherit;
+    --typeset-font-heading: var(--font-heading);
+    --typeset-font-mono:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+      'Courier New', monospace;
+    --typeset-size: 1em;
+    --typeset-leading: 1.75;
+    --typeset-flow: 1.25em;
+
+    color: var(--muted-foreground);
+    font-family: var(--typeset-font-body);
+    font-size: var(--typeset-size);
+    line-height: var(--typeset-leading);
+  }
+
+  .typeset-portfolio {
+    --typeset-font-body: var(--font-sans);
+    --typeset-font-heading: var(--font-heading);
+    --typeset-size: 1rem;
+    --typeset-leading: 1.75;
+    --typeset-flow: 1.25em;
+  }
+
+  .dark .typeset {
+    --typeset-leading: 1.85;
+  }
+
+  .typeset
+    :where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    overflow-wrap: break-word;
+  }
+
+  .typeset
+    :where(
+      p,
+      ul,
+      ol,
+      dl,
+      blockquote,
+      pre,
+      table,
+      figure,
+      hr,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6
+    ):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    margin-block: 0;
+  }
+
+  .typeset
+    :where(p, ul, ol, dl, blockquote, pre, table, figure, hr):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    )
+    + :where(
+      p,
+      ul,
+      ol,
+      dl,
+      blockquote,
+      pre,
+      table,
+      figure,
+      hr,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6
+    ):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    margin-block-start: var(--typeset-flow);
+  }
+
+  .typeset
+    :where(h2, h3, h4, h5, h6):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    color: var(--foreground);
+    font-family: var(--typeset-font-heading);
+    font-weight: 700;
+    line-height: 1.15;
+  }
+
+  .typeset
+    :where(h2):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    font-size: 1.5em;
+    margin-block-start: calc(var(--typeset-flow) * 2);
+  }
+
+  .typeset
+    > :where(h2, h3, h4, h5, h6):first-child:where(
+      :not(.not-typeset, [data-not-typeset])
+    ) {
+    margin-block-start: 0;
+  }
+
+  .typeset
+    :where(h3):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    font-size: 1.25em;
+    margin-block-start: calc(var(--typeset-flow) * 1.6);
+  }
+
+  .typeset
+    :where(h4, h5, h6):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    font-size: 1em;
+    margin-block-start: calc(var(--typeset-flow) * 1.4);
+  }
+
+  .typeset
+    :where(ul, ol):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    padding-inline-start: 1.5em;
+  }
+
+  .typeset
+    :where(ul):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    list-style: disc;
+  }
+
+  .typeset
+    :where(ol):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    list-style: decimal;
+  }
+
+  .typeset
+    :where(li + li):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    margin-block-start: calc(var(--typeset-flow) * 0.4);
+  }
+
+  .typeset
+    :where(a):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    color: var(--foreground);
+    border-radius: calc(var(--radius) * 0.5);
+    font-weight: 650;
+    text-decoration-line: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 0.25em;
+  }
+
+  .typeset
+    :where(a:hover):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    color: var(--primary);
+  }
+
+  .typeset
+    :where(a:focus-visible):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+  }
+
+  .typeset
+    :where(code, kbd):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    border-radius: calc(var(--radius) * 0.5);
+    background: var(--muted);
+    color: var(--foreground);
+    font-family: var(--typeset-font-mono);
+    font-size: 0.9em;
+    padding: 0.15em 0.35em;
+  }
+
+  .typeset
+    :where(pre):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    overflow-x: auto;
+    border-radius: var(--radius);
+    background: var(--muted);
+    padding: 1em;
+  }
+
+  .typeset
+    :where(pre code):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    background: transparent;
+    padding: 0;
+  }
+
+  .typeset
+    :where(blockquote):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    border-inline-start: 3px solid var(--border);
+    color: var(--foreground);
+    padding-inline-start: 1em;
+  }
+
+  .typeset
+    :where(hr):where(
+      :not(
+        .not-typeset,
+        [data-not-typeset],
+        .not-typeset *,
+        [data-not-typeset] *
+      )
+    ) {
+    border: 0;
+    border-block-start: 1px solid var(--border);
+    margin-block-start: calc(var(--typeset-flow) * 2);
+  }
+
+  .typeset-scroll {
+    overflow-x: auto;
+  }
+}


### PR DESCRIPTION
## What changed
- Updated wedding pricing on the services page.
- Saved the pricing research in `docs/tampa-wedding-video-pricing-research.md`.

## Why
- The previous wedding/event price was too low for the amount of coverage, editing, and delivery work involved.
- The research file captures the pricing basis used for the update.

## Impact
- The site now presents a clearer wedding documentation offer and add-ons.
- The research is tracked in-repo for future edits.

## Validation
- `npm run verify`
